### PR TITLE
feat: add role and scope data model for B01

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,20 @@ npm run dev
 ```bash
 npm run check
 npm run build
+npm test
 npm run db:generate
 npm run db:migrate
 npm run db:studio
 ```
+
+## 当前数据模型（B01）
+
+- 组织层级：`schools` / `colleges` / `classes` / `students`
+- 角色：`roles`（student/teacher/admin）
+- 授权范围：`auth_scopes`（school/college/class/student）
+- 角色范围关联：`role_scopes`
+
+支持通过 `class_id` / `student_id` 表达授权范围。
 
 ## 健康检查
 

--- a/docs/plans/2026-03-01-b01-role-scope-model-design.md
+++ b/docs/plans/2026-03-01-b01-role-scope-model-design.md
@@ -1,0 +1,48 @@
+# B01 角色与范围数据模型设计
+
+## 背景
+任务 B01 需建立 Student/Teacher/Admin 角色模型，以及 School/College/Class/Student 的授权范围表达能力，并确保迁移可重复执行。
+
+## 目标
+1. 提供角色表、范围表、关联表。
+2. 范围表可直接表达 `class_id` 与 `student_id`。
+3. 为后续 B02/B03/A04 留出扩展点。
+
+## 方案对比
+
+### 方案 A（推荐）：通用 role + scope + role_scope
+- `roles`：角色字典（student/teacher/admin）
+- `auth_scopes`：范围实例（school/college/class/student）+ 组织/学生外键
+- `role_scopes`：角色与范围关联
+- 优点：满足当前验收；模型简单；后续易接入用户授权
+- 缺点：不直接表示“具体用户被授予该范围”，后续任务补齐
+
+### 方案 B：直接做 user_role_scope 三元模型
+- 一次引入用户账号、角色、范围三元关系
+- 优点：一步到位
+- 缺点：超出 B01 范围，和 B02 认证耦合过早
+
+### 方案 C：纯枚举字段（无独立字典表）
+- 在授权表直接写 role/scope_type 字符串
+- 优点：开发快
+- 缺点：一致性差、扩展困难
+
+## 采用方案
+采用方案 A。
+
+## 数据模型
+- `schools` / `colleges` / `classes` / `students`
+- `roles`
+- `auth_scopes`（含 `scope_type`、`school_id`、`college_id`、`class_id`、`student_id`）
+- `role_scopes`
+
+## 约束
+- `roles.code` 唯一
+- `students.student_no` 唯一
+- `auth_scopes` 对 `class_id`、`student_id` 建索引
+- `role_scopes(role_id, scope_id)` 唯一
+
+## 测试与验证
+- 通过测试验证 schema 暴露了核心表与关键列（含 `class_id`/`student_id`）。
+- `npm run db:generate` 生成迁移。
+- 使用 drizzle migration 机制保证重复执行安全（已执行迁移不会重复应用）。

--- a/docs/plans/2026-03-01-b01-role-scope-model.md
+++ b/docs/plans/2026-03-01-b01-role-scope-model.md
@@ -1,0 +1,57 @@
+# B01 Role Scope Model Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 在 MySQL/Drizzle 中实现角色、范围、关联模型，满足 `class_id`/`student_id` 级授权表达。
+
+**Architecture:** 采用 `roles + auth_scopes + role_scopes` 三表为核心，配合组织层级表（school/college/class/student）支撑外键与层级范围表达。先通过失败测试定义目标，再最小实现 schema，最后生成迁移并验证。
+
+**Tech Stack:** TypeScript, Drizzle ORM, drizzle-kit, Node.js test runner
+
+---
+
+### Task 1: 建立测试基线（TDD Red）
+
+**Files:**
+- Create: `tests/db/schema.test.ts`
+- Modify: `package.json`
+
+**Step 1: 写失败测试**
+- 断言存在 `roles`、`authScopes`、`roleScopes`。
+- 断言 `authScopes` 含 `classId`、`studentId`。
+
+**Step 2: 运行并确认失败**
+- Run: `npm test`
+- 预期：因缺少导出/字段而失败。
+
+### Task 2: 实现最小 schema（TDD Green）
+
+**Files:**
+- Modify: `src/db/schema.ts`
+
+**Step 1: 增加组织与授权相关表**
+- 新增 `schools/colleges/classes/roles/auth_scopes/role_scopes`。
+- 扩展 `students` 增加 `class_id` 外键与唯一学号。
+
+**Step 2: 再跑测试**
+- Run: `npm test`
+- 预期：测试通过。
+
+### Task 3: 生成 migration 并验证
+
+**Files:**
+- Create/Modify: `drizzle/*`
+
+**Step 1: 生成迁移**
+- Run: `npm run db:generate`
+
+**Step 2: 类型与构建验证**
+- Run: `npm run check && npm run build`
+
+### Task 4: 记录进展与交付
+
+**Files:**
+- Modify: `README.md`（如需补充）
+
+**Step 1:** 汇总变更与验证结果。
+**Step 2:** 在 Issue #3 留进展 comment。

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,16 +1,25 @@
+import { config } from "dotenv";
 import { defineConfig } from "drizzle-kit";
-import { env } from "./src/config/env.js";
+
+config();
+
+const REQUIRED_KEYS = ["DB_HOST", "DB_PORT", "DB_USER", "DB_PASSWORD", "DB_NAME"] as const;
+
+for (const key of REQUIRED_KEYS) {
+  if (!process.env[key]) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+}
 
 export default defineConfig({
   out: "./drizzle",
   schema: "./src/db/schema.ts",
   dialect: "mysql",
   dbCredentials: {
-    host: env.DB_HOST,
-    port: env.DB_PORT,
-    user: env.DB_USER,
-    password: env.DB_PASSWORD,
-    database: env.DB_NAME
+    host: process.env.DB_HOST as string,
+    port: Number(process.env.DB_PORT),
+    user: process.env.DB_USER as string,
+    password: process.env.DB_PASSWORD as string,
+    database: process.env.DB_NAME as string
   }
 });
-

--- a/drizzle/0000_giant_tomas.sql
+++ b/drizzle/0000_giant_tomas.sql
@@ -1,0 +1,80 @@
+CREATE TABLE `auth_scopes` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`scope_type` enum('school','college','class','student') NOT NULL,
+	`school_id` int,
+	`college_id` int,
+	`class_id` int,
+	`student_id` int,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `auth_scopes_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `classes` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`college_id` int NOT NULL,
+	`name` varchar(128) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `classes_id` PRIMARY KEY(`id`),
+	CONSTRAINT `classes_college_id_name_unique` UNIQUE(`college_id`,`name`)
+);
+--> statement-breakpoint
+CREATE TABLE `colleges` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`school_id` int NOT NULL,
+	`name` varchar(128) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `colleges_id` PRIMARY KEY(`id`),
+	CONSTRAINT `colleges_school_id_name_unique` UNIQUE(`school_id`,`name`)
+);
+--> statement-breakpoint
+CREATE TABLE `role_scopes` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`role_id` int NOT NULL,
+	`scope_id` int NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `role_scopes_id` PRIMARY KEY(`id`),
+	CONSTRAINT `role_scopes_role_id_scope_id_unique` UNIQUE(`role_id`,`scope_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `roles` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`code` enum('student','teacher','admin') NOT NULL,
+	`name` varchar(64) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `roles_id` PRIMARY KEY(`id`),
+	CONSTRAINT `roles_code_unique` UNIQUE(`code`)
+);
+--> statement-breakpoint
+CREATE TABLE `schools` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`name` varchar(128) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `schools_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `students` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`class_id` int NOT NULL,
+	`student_no` varchar(32) NOT NULL,
+	`name` varchar(64) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `students_id` PRIMARY KEY(`id`),
+	CONSTRAINT `students_student_no_unique` UNIQUE(`student_no`)
+);
+--> statement-breakpoint
+ALTER TABLE `auth_scopes` ADD CONSTRAINT `auth_scopes_school_id_schools_id_fk` FOREIGN KEY (`school_id`) REFERENCES `schools`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `auth_scopes` ADD CONSTRAINT `auth_scopes_college_id_colleges_id_fk` FOREIGN KEY (`college_id`) REFERENCES `colleges`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `auth_scopes` ADD CONSTRAINT `auth_scopes_class_id_classes_id_fk` FOREIGN KEY (`class_id`) REFERENCES `classes`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `auth_scopes` ADD CONSTRAINT `auth_scopes_student_id_students_id_fk` FOREIGN KEY (`student_id`) REFERENCES `students`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `classes` ADD CONSTRAINT `classes_college_id_colleges_id_fk` FOREIGN KEY (`college_id`) REFERENCES `colleges`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `colleges` ADD CONSTRAINT `colleges_school_id_schools_id_fk` FOREIGN KEY (`school_id`) REFERENCES `schools`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `role_scopes` ADD CONSTRAINT `role_scopes_role_id_roles_id_fk` FOREIGN KEY (`role_id`) REFERENCES `roles`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `role_scopes` ADD CONSTRAINT `role_scopes_scope_id_auth_scopes_id_fk` FOREIGN KEY (`scope_id`) REFERENCES `auth_scopes`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE `students` ADD CONSTRAINT `students_class_id_classes_id_fk` FOREIGN KEY (`class_id`) REFERENCES `classes`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `auth_scopes_school_id_idx` ON `auth_scopes` (`school_id`);--> statement-breakpoint
+CREATE INDEX `auth_scopes_college_id_idx` ON `auth_scopes` (`college_id`);--> statement-breakpoint
+CREATE INDEX `auth_scopes_class_id_idx` ON `auth_scopes` (`class_id`);--> statement-breakpoint
+CREATE INDEX `auth_scopes_student_id_idx` ON `auth_scopes` (`student_id`);--> statement-breakpoint
+CREATE INDEX `role_scopes_role_id_idx` ON `role_scopes` (`role_id`);--> statement-breakpoint
+CREATE INDEX `role_scopes_scope_id_idx` ON `role_scopes` (`scope_id`);--> statement-breakpoint
+CREATE INDEX `students_class_id_idx` ON `students` (`class_id`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,576 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "ffbd08e8-3983-44d0-8bae-48b24afccf4f",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "auth_scopes": {
+      "name": "auth_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "enum('school','college','class','student')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "auth_scopes_school_id_idx": {
+          "name": "auth_scopes_school_id_idx",
+          "columns": [
+            "school_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_college_id_idx": {
+          "name": "auth_scopes_college_id_idx",
+          "columns": [
+            "college_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_class_id_idx": {
+          "name": "auth_scopes_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_student_id_idx": {
+          "name": "auth_scopes_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_scopes_school_id_schools_id_fk": {
+          "name": "auth_scopes_school_id_schools_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_college_id_colleges_id_fk": {
+          "name": "auth_scopes_college_id_colleges_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_class_id_classes_id_fk": {
+          "name": "auth_scopes_class_id_classes_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_student_id_students_id_fk": {
+          "name": "auth_scopes_student_id_students_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_scopes_id": {
+          "name": "auth_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "classes": {
+      "name": "classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "classes_college_id_name_unique": {
+          "name": "classes_college_id_name_unique",
+          "columns": [
+            "college_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "classes_college_id_colleges_id_fk": {
+          "name": "classes_college_id_colleges_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "classes_id": {
+          "name": "classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "colleges": {
+      "name": "colleges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "colleges_school_id_name_unique": {
+          "name": "colleges_school_id_name_unique",
+          "columns": [
+            "school_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "colleges_school_id_schools_id_fk": {
+          "name": "colleges_school_id_schools_id_fk",
+          "tableFrom": "colleges",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "colleges_id": {
+          "name": "colleges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "role_scopes": {
+      "name": "role_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "role_scopes_role_id_scope_id_unique": {
+          "name": "role_scopes_role_id_scope_id_unique",
+          "columns": [
+            "role_id",
+            "scope_id"
+          ],
+          "isUnique": true
+        },
+        "role_scopes_role_id_idx": {
+          "name": "role_scopes_role_id_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_scopes_scope_id_idx": {
+          "name": "role_scopes_scope_id_idx",
+          "columns": [
+            "scope_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_scopes_role_id_roles_id_fk": {
+          "name": "role_scopes_role_id_roles_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_scopes_scope_id_auth_scopes_id_fk": {
+          "name": "role_scopes_scope_id_auth_scopes_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "auth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_scopes_id": {
+          "name": "role_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "enum('student','teacher','admin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "roles_code_unique": {
+          "name": "roles_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "roles_id": {
+          "name": "roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schools": {
+      "name": "schools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schools_id": {
+          "name": "schools_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "students": {
+      "name": "students",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_no": {
+          "name": "student_no",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "students_student_no_unique": {
+          "name": "students_student_no_unique",
+          "columns": [
+            "student_no"
+          ],
+          "isUnique": true
+        },
+        "students_class_id_idx": {
+          "name": "students_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "students_class_id_classes_id_fk": {
+          "name": "students_class_id_classes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "students_id": {
+          "name": "students_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "mysql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "5",
+      "when": 1772364544884,
+      "tag": "0000_giant_tomas",
+      "breakpoints": true
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "test": "node --import tsx --test \"tests/**/*.test.ts\""
   },
   "dependencies": {
     "@hono/node-server": "^1.13.8",
@@ -26,4 +27,3 @@
     "typescript": "^5.7.2"
   }
 }
-

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,9 +1,113 @@
-import { int, mysqlTable, timestamp, varchar } from "drizzle-orm/mysql-core";
+import {
+  index,
+  int,
+  mysqlEnum,
+  mysqlTable,
+  timestamp,
+  uniqueIndex,
+  varchar
+} from "drizzle-orm/mysql-core";
 
-export const students = mysqlTable("students", {
+export const schools = mysqlTable("schools", {
   id: int("id").autoincrement().primaryKey(),
-  studentNo: varchar("student_no", { length: 32 }).notNull(),
-  name: varchar("name", { length: 64 }).notNull(),
+  name: varchar("name", { length: 128 }).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull()
 });
 
+export const colleges = mysqlTable(
+  "colleges",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    schoolId: int("school_id")
+      .notNull()
+      .references(() => schools.id),
+    name: varchar("name", { length: 128 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    schoolNameUnique: uniqueIndex("colleges_school_id_name_unique").on(table.schoolId, table.name)
+  })
+);
+
+export const classes = mysqlTable(
+  "classes",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    collegeId: int("college_id")
+      .notNull()
+      .references(() => colleges.id),
+    name: varchar("name", { length: 128 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    collegeNameUnique: uniqueIndex("classes_college_id_name_unique").on(table.collegeId, table.name)
+  })
+);
+
+export const students = mysqlTable(
+  "students",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    classId: int("class_id")
+      .notNull()
+      .references(() => classes.id),
+    studentNo: varchar("student_no", { length: 32 }).notNull(),
+    name: varchar("name", { length: 64 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    studentNoUnique: uniqueIndex("students_student_no_unique").on(table.studentNo),
+    classIdIdx: index("students_class_id_idx").on(table.classId)
+  })
+);
+
+export const roles = mysqlTable(
+  "roles",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    code: mysqlEnum("code", ["student", "teacher", "admin"]).notNull(),
+    name: varchar("name", { length: 64 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    roleCodeUnique: uniqueIndex("roles_code_unique").on(table.code)
+  })
+);
+
+export const authScopes = mysqlTable(
+  "auth_scopes",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    scopeType: mysqlEnum("scope_type", ["school", "college", "class", "student"]).notNull(),
+    schoolId: int("school_id").references(() => schools.id),
+    collegeId: int("college_id").references(() => colleges.id),
+    classId: int("class_id").references(() => classes.id),
+    studentId: int("student_id").references(() => students.id),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    schoolIdIdx: index("auth_scopes_school_id_idx").on(table.schoolId),
+    collegeIdIdx: index("auth_scopes_college_id_idx").on(table.collegeId),
+    classIdIdx: index("auth_scopes_class_id_idx").on(table.classId),
+    studentIdIdx: index("auth_scopes_student_id_idx").on(table.studentId)
+  })
+);
+
+export const roleScopes = mysqlTable(
+  "role_scopes",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    roleId: int("role_id")
+      .notNull()
+      .references(() => roles.id),
+    scopeId: int("scope_id")
+      .notNull()
+      .references(() => authScopes.id),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    roleScopeUnique: uniqueIndex("role_scopes_role_id_scope_id_unique").on(table.roleId, table.scopeId),
+    roleIdIdx: index("role_scopes_role_id_idx").on(table.roleId),
+    scopeIdIdx: index("role_scopes_scope_id_idx").on(table.scopeId)
+  })
+);

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { authScopes, roleScopes, roles } from "../../src/db/schema.ts";
+
+test("schema should expose role/scope association tables", () => {
+  assert.equal(roles[Symbol.for("drizzle:Name")], "roles");
+  assert.equal(authScopes[Symbol.for("drizzle:Name")], "auth_scopes");
+  assert.equal(roleScopes[Symbol.for("drizzle:Name")], "role_scopes");
+});
+
+test("auth_scopes should support class_id and student_id authorization", () => {
+  assert.equal(authScopes.classId.name, "class_id");
+  assert.equal(authScopes.studentId.name, "student_id");
+});
+
+test("role_scopes should include role_id and scope_id", () => {
+  assert.equal(roleScopes.roleId.name, "role_id");
+  assert.equal(roleScopes.scopeId.name, "scope_id");
+});


### PR DESCRIPTION
## Summary
- add B01 role/scope core schema: `roles`, `auth_scopes`, `role_scopes`
- add organization hierarchy tables: `schools`, `colleges`, `classes`, and extend `students.class_id`
- add schema tests and generate drizzle migration

## Test Plan
- [x] npm run check
- [x] npm run build
- [x] npm test
- [x] npm run db:generate

Closes #3
