### PR TITLE
feat: 完成 B04 授权与关键操作审计日志

### DIFF
--- a/docs/plans/2026-03-01-b04-audit-log-design.md
+++ b/docs/plans/2026-03-01-b04-audit-log-design.md
@@ -1,0 +1,42 @@
+# B04 授权与关键操作审计日志设计
+
+## 任务
+Issue #6（B04）：授权分配/撤销、密码重置、活动发布均写审计日志；日志需包含操作者、目标、时间、动作。
+
+## 设计目标
+- 建立统一审计日志模型，避免各接口自行拼接日志字段。
+- 先覆盖当前可落地关键操作：
+  - 管理员重置密码
+  - 授权分配/撤销
+  - 活动发布
+- 保持后续 A01/A04/A06 可复用。
+
+## 数据模型
+新增表：
+1. `activities`
+   - `activity_type`（course/competition/project）
+   - `title`
+   - `created_at`
+2. `audit_logs`
+   - `operator`（操作者）
+   - `action`（authorization_grant / authorization_revoke / password_reset / activity_publish）
+   - `target`（目标）
+   - `detail`（补充信息）
+   - `created_at`（时间）
+
+## 应用层方案
+- 新增审计服务 `modules/audit/service.ts`
+  - 统一写入 operator/action/target/createdAt
+- 新增授权分配服务 `modules/authorization/grant-service.ts`
+- 新增活动发布服务 `modules/activity/service.ts`
+- 在 `routes/admin.ts` 中接入：
+  - `POST /admin/students/:id/reset-password`
+  - `POST /admin/authorizations/grants`
+  - `DELETE /admin/authorizations/grants`
+  - `POST /admin/activities`
+
+## 验收映射
+- 授权分配/撤销写审计 ✅
+- 密码重置写审计 ✅
+- 活动发布写审计 ✅
+- 日志含操作者/目标/时间/动作 ✅

--- a/docs/plans/2026-03-01-b04-audit-log.md
+++ b/docs/plans/2026-03-01-b04-audit-log.md
@@ -1,0 +1,55 @@
+# B04 Audit Log Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为授权与关键操作建立统一审计日志能力并接入管理员关键操作接口。
+
+**Architecture:** 采用“审计服务 + 关键操作服务 + 管理路由接入 + 迁移测试”方式，先用 TDD 固定行为，再补数据模型和集成。
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, Node test runner
+
+---
+
+### Task 1: 审计服务 RED/GREEN
+
+**Files:**
+- Create: `tests/audit/audit-service.test.ts`
+- Create: `src/modules/audit/service.ts`
+
+**Step 1:** 先写失败测试，约束四类动作均写 operator/target/action/time。
+**Step 2:** 运行单测确认 RED。
+**Step 3:** 最小实现审计服务并转 GREEN。
+
+### Task 2: 管理端关键操作 RED/GREEN
+
+**Files:**
+- Create: `tests/auth/admin-audit-operations.test.ts`
+- Modify: `src/routes/admin.ts`
+- Create: `src/modules/authorization/grant-service.ts`
+- Create: `src/modules/activity/service.ts`
+
+**Step 1:** 为授权分配/撤销、活动发布写失败接口测试。
+**Step 2:** 扩展 admin 路由并接入审计服务。
+**Step 3:** 跑测试转 GREEN。
+
+### Task 3: 数据模型与迁移
+
+**Files:**
+- Modify: `src/db/schema.ts`
+- Create: `drizzle/0004_*.sql`
+- Modify: `drizzle/meta/*`
+
+**Step 1:** 新增 `activities`、`audit_logs`。
+**Step 2:** 生成迁移并更新元数据。
+
+### Task 4: 索引层接线与回归
+
+**Files:**
+- Modify: `src/index.ts`
+- Modify: `tests/auth/admin-reset-password.test.ts`
+- Modify: `tests/db/schema.test.ts`
+- Modify: `tests/db/migrations.test.ts`
+
+**Step 1:** 在 index 中组装 activity/grant/audit repo 与 service。
+**Step 2:** 补充 admin reset 测试中的审计断言。
+**Step 3:** 全量验证并收口。

--- a/drizzle/0004_conscious_hex.sql
+++ b/drizzle/0004_conscious_hex.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `activities` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`activity_type` enum('course','competition','project') NOT NULL,
+	`title` varchar(128) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `activities_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `audit_logs` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`operator` varchar(64) NOT NULL,
+	`action` enum('authorization_grant','authorization_revoke','password_reset','activity_publish') NOT NULL,
+	`target` varchar(191) NOT NULL,
+	`detail` varchar(255),
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `audit_logs_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE INDEX `activities_activity_type_idx` ON `activities` (`activity_type`);--> statement-breakpoint
+CREATE INDEX `audit_logs_action_idx` ON `audit_logs` (`action`);--> statement-breakpoint
+CREATE INDEX `audit_logs_operator_idx` ON `audit_logs` (`operator`);--> statement-breakpoint
+CREATE INDEX `audit_logs_target_idx` ON `audit_logs` (`target`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1144 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "f82f8f72-1eaa-47bd-94ea-cc3070ab562b",
+  "prevId": "e0a7dca4-e922-40a7-b277-242a49590983",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "enum('course','competition','project')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "activities_activity_type_idx": {
+          "name": "activities_activity_type_idx",
+          "columns": [
+            "activity_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activities_id": {
+          "name": "activities_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('authorization_grant','authorization_revoke','password_reset','activity_publish')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_operator_idx": {
+          "name": "audit_logs_operator_idx",
+          "columns": [
+            "operator"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_target_idx": {
+          "name": "audit_logs_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "auth_scopes": {
+      "name": "auth_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "enum('school','college','class','student')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "auth_scopes_school_id_idx": {
+          "name": "auth_scopes_school_id_idx",
+          "columns": [
+            "school_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_college_id_idx": {
+          "name": "auth_scopes_college_id_idx",
+          "columns": [
+            "college_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_class_id_idx": {
+          "name": "auth_scopes_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_student_id_idx": {
+          "name": "auth_scopes_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_scopes_school_id_schools_id_fk": {
+          "name": "auth_scopes_school_id_schools_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_college_id_colleges_id_fk": {
+          "name": "auth_scopes_college_id_colleges_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_class_id_classes_id_fk": {
+          "name": "auth_scopes_class_id_classes_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_student_id_students_id_fk": {
+          "name": "auth_scopes_student_id_students_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_scopes_id": {
+          "name": "auth_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "certificates_student_id_idx": {
+          "name": "certificates_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_student_id_students_id_fk": {
+          "name": "certificates_student_id_students_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "classes": {
+      "name": "classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "classes_college_id_name_unique": {
+          "name": "classes_college_id_name_unique",
+          "columns": [
+            "college_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "classes_college_id_colleges_id_fk": {
+          "name": "classes_college_id_colleges_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "classes_id": {
+          "name": "classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "colleges": {
+      "name": "colleges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "colleges_school_id_name_unique": {
+          "name": "colleges_school_id_name_unique",
+          "columns": [
+            "school_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "colleges_school_id_schools_id_fk": {
+          "name": "colleges_school_id_schools_id_fk",
+          "tableFrom": "colleges",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "colleges_id": {
+          "name": "colleges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "profiles_student_id_idx": {
+          "name": "profiles_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_student_id_students_id_fk": {
+          "name": "profiles_student_id_students_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profiles_id": {
+          "name": "profiles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "reports_student_id_idx": {
+          "name": "reports_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_student_id_students_id_fk": {
+          "name": "reports_student_id_students_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reports_id": {
+          "name": "reports_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "role_scopes": {
+      "name": "role_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "role_scopes_role_id_scope_id_unique": {
+          "name": "role_scopes_role_id_scope_id_unique",
+          "columns": [
+            "role_id",
+            "scope_id"
+          ],
+          "isUnique": true
+        },
+        "role_scopes_role_id_idx": {
+          "name": "role_scopes_role_id_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_scopes_scope_id_idx": {
+          "name": "role_scopes_scope_id_idx",
+          "columns": [
+            "scope_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_scopes_role_id_roles_id_fk": {
+          "name": "role_scopes_role_id_roles_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_scopes_scope_id_auth_scopes_id_fk": {
+          "name": "role_scopes_scope_id_auth_scopes_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "auth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_scopes_id": {
+          "name": "role_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "enum('student','teacher','admin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "roles_code_unique": {
+          "name": "roles_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "roles_id": {
+          "name": "roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schools": {
+      "name": "schools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schools_id": {
+          "name": "schools_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "students": {
+      "name": "students",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_no": {
+          "name": "student_no",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "password_updated_at": {
+          "name": "password_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "students_student_no_unique": {
+          "name": "students_student_no_unique",
+          "columns": [
+            "student_no"
+          ],
+          "isUnique": true
+        },
+        "students_class_id_idx": {
+          "name": "students_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "students_class_id_classes_id_fk": {
+          "name": "students_class_id_classes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "students_id": {
+          "name": "students_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tasks_student_id_idx": {
+          "name": "tasks_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_student_id_students_id_fk": {
+          "name": "tasks_student_id_students_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id": {
+          "name": "tasks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_class_grants": {
+      "name": "teacher_class_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_class_grants_teacher_class_unique": {
+          "name": "teacher_class_grants_teacher_class_unique",
+          "columns": [
+            "teacher_id",
+            "class_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_class_grants_teacher_id_idx": {
+          "name": "teacher_class_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_class_grants_class_id_idx": {
+          "name": "teacher_class_grants_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_class_grants_class_id_classes_id_fk": {
+          "name": "teacher_class_grants_class_id_classes_id_fk",
+          "tableFrom": "teacher_class_grants",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_class_grants_id": {
+          "name": "teacher_class_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_student_grants": {
+      "name": "teacher_student_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_student_grants_teacher_student_unique": {
+          "name": "teacher_student_grants_teacher_student_unique",
+          "columns": [
+            "teacher_id",
+            "student_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_student_grants_teacher_id_idx": {
+          "name": "teacher_student_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_student_grants_student_id_idx": {
+          "name": "teacher_student_grants_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_student_grants_student_id_students_id_fk": {
+          "name": "teacher_student_grants_student_id_students_id_fk",
+          "tableFrom": "teacher_student_grants",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_grants_id": {
+          "name": "teacher_student_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772375619723,
       "tag": "0003_cold_zombie",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1772376427694,
+      "tag": "0004_conscious_hex",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -161,6 +161,41 @@ export const teacherClassGrants = mysqlTable(
   })
 );
 
+export const activities = mysqlTable(
+  "activities",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    activityType: mysqlEnum("activity_type", ["course", "competition", "project"]).notNull(),
+    title: varchar("title", { length: 128 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    activityTypeIdx: index("activities_activity_type_idx").on(table.activityType)
+  })
+);
+
+export const auditLogs = mysqlTable(
+  "audit_logs",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    operator: varchar("operator", { length: 64 }).notNull(),
+    action: mysqlEnum("action", [
+      "authorization_grant",
+      "authorization_revoke",
+      "password_reset",
+      "activity_publish"
+    ]).notNull(),
+    target: varchar("target", { length: 191 }).notNull(),
+    detail: varchar("detail", { length: 255 }),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    actionIdx: index("audit_logs_action_idx").on(table.action),
+    operatorIdx: index("audit_logs_operator_idx").on(table.operator),
+    targetIdx: index("audit_logs_target_idx").on(table.target)
+  })
+);
+
 export const roles = mysqlTable(
   "roles",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import { Hono } from "hono";
 import { env } from "./config/env.js";
 import { db } from "./db/client.js";
 import {
+  activities,
+  auditLogs,
   certificates,
   profiles,
   reports,
@@ -14,6 +16,9 @@ import {
 } from "./db/schema.js";
 import { createStudentAuthMiddleware } from "./middleware/auth.js";
 import { createResourceAuthorizationMiddleware } from "./middleware/resource-authorization.js";
+import { createActivityService } from "./modules/activity/service.js";
+import { createAuditLogService } from "./modules/audit/service.js";
+import { createAuthorizationGrantService } from "./modules/authorization/grant-service.js";
 import { createResourceAuthorizationService, type ResourceType } from "./modules/authorization/service.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
@@ -163,6 +168,102 @@ const resourceAuthorizationService = createResourceAuthorizationService({
   authorizationRepo
 });
 
+const authorizationGrantRepo = {
+  async assignStudentGrant(teacherId: string, studentId: number): Promise<void> {
+    const existing = await db
+      .select({ id: teacherStudentGrants.id })
+      .from(teacherStudentGrants)
+      .where(and(eq(teacherStudentGrants.teacherId, teacherId), eq(teacherStudentGrants.studentId, studentId)))
+      .limit(1);
+
+    if (existing.length > 0) {
+      return;
+    }
+
+    await db.insert(teacherStudentGrants).values({
+      teacherId,
+      studentId
+    });
+  },
+  async revokeStudentGrant(teacherId: string, studentId: number): Promise<void> {
+    await db
+      .delete(teacherStudentGrants)
+      .where(and(eq(teacherStudentGrants.teacherId, teacherId), eq(teacherStudentGrants.studentId, studentId)));
+  },
+  async assignClassGrant(teacherId: string, classId: number): Promise<void> {
+    const existing = await db
+      .select({ id: teacherClassGrants.id })
+      .from(teacherClassGrants)
+      .where(and(eq(teacherClassGrants.teacherId, teacherId), eq(teacherClassGrants.classId, classId)))
+      .limit(1);
+
+    if (existing.length > 0) {
+      return;
+    }
+
+    await db.insert(teacherClassGrants).values({
+      teacherId,
+      classId
+    });
+  },
+  async revokeClassGrant(teacherId: string, classId: number): Promise<void> {
+    await db
+      .delete(teacherClassGrants)
+      .where(and(eq(teacherClassGrants.teacherId, teacherId), eq(teacherClassGrants.classId, classId)));
+  }
+};
+
+const authorizationGrantService = createAuthorizationGrantService({
+  authorizationGrantRepo
+});
+
+const activityRepo = {
+  async publishActivity({
+    activityType,
+    title
+  }: {
+    activityType: "course" | "competition" | "project";
+    title: string;
+  }): Promise<void> {
+    await db.insert(activities).values({
+      activityType,
+      title
+    });
+  }
+};
+
+const activityService = createActivityService({
+  activityRepo
+});
+
+const auditLogRepo = {
+  async createAuditLog({
+    operator,
+    action,
+    target,
+    detail,
+    createdAt
+  }: {
+    operator: string;
+    action: "authorization_grant" | "authorization_revoke" | "password_reset" | "activity_publish";
+    target: string;
+    detail: string | null;
+    createdAt: Date;
+  }): Promise<void> {
+    await db.insert(auditLogs).values({
+      operator,
+      action,
+      target,
+      detail,
+      createdAt
+    });
+  }
+};
+
+const auditLogService = createAuditLogService({
+  auditLogRepo
+});
+
 const createResourceAuthorization = (resourceType: ResourceType) =>
   createResourceAuthorizationMiddleware({
     resourceType,
@@ -184,6 +285,9 @@ app.route(
   "/admin",
   createAdminRoutes({
     studentAuthService,
+    authorizationGrantService,
+    activityService,
+    auditLogService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/modules/activity/service.ts
+++ b/src/modules/activity/service.ts
@@ -1,0 +1,26 @@
+export type ActivityType = "course" | "competition" | "project";
+
+export interface PublishActivityInput {
+  activityType: ActivityType;
+  title: string;
+}
+
+export interface ActivityRepository {
+  publishActivity(input: PublishActivityInput): Promise<void>;
+}
+
+export interface ActivityService {
+  publishActivity(input: PublishActivityInput): Promise<void>;
+}
+
+export interface CreateActivityServiceInput {
+  activityRepo: ActivityRepository;
+}
+
+export const createActivityService = ({ activityRepo }: CreateActivityServiceInput): ActivityService => {
+  return {
+    async publishActivity(input: PublishActivityInput): Promise<void> {
+      await activityRepo.publishActivity(input);
+    }
+  };
+};

--- a/src/modules/audit/service.ts
+++ b/src/modules/audit/service.ts
@@ -1,0 +1,107 @@
+export type AuditAction =
+  | "authorization_grant"
+  | "authorization_revoke"
+  | "password_reset"
+  | "activity_publish";
+
+export interface PersistAuditLogInput {
+  operator: string;
+  action: AuditAction;
+  target: string;
+  detail: string | null;
+  createdAt: Date;
+}
+
+export interface AuditLogRepository {
+  createAuditLog(input: PersistAuditLogInput): Promise<void>;
+}
+
+export type AuthorizationGrantType = "student" | "class";
+export type ActivityType = "course" | "competition" | "project";
+
+export interface LogAuthorizationAuditInput {
+  operator: string;
+  teacherId: string;
+  grantType: AuthorizationGrantType;
+  targetId: number;
+}
+
+export interface LogPasswordResetAuditInput {
+  operator: string;
+  studentId: number;
+}
+
+export interface LogActivityPublishAuditInput {
+  operator: string;
+  activityType: ActivityType;
+  activityTitle: string;
+}
+
+export interface AuditLogService {
+  logAuthorizationGrant(input: LogAuthorizationAuditInput): Promise<void>;
+  logAuthorizationRevoke(input: LogAuthorizationAuditInput): Promise<void>;
+  logPasswordReset(input: LogPasswordResetAuditInput): Promise<void>;
+  logActivityPublish(input: LogActivityPublishAuditInput): Promise<void>;
+}
+
+export interface CreateAuditLogServiceInput {
+  auditLogRepo: AuditLogRepository;
+}
+
+const normalizeOperator = (operator: string): string => {
+  const normalized = operator.trim();
+  return normalized.length > 0 ? normalized : "system-admin";
+};
+
+const normalizeTitle = (activityTitle: string): string => {
+  const normalized = activityTitle.trim();
+  return normalized.length > 0 ? normalized : "untitled";
+};
+
+const createAuditTarget = (resourceType: string, identifier: string | number): string => {
+  return `${resourceType}:${identifier}`;
+};
+
+export const createAuditLogService = ({ auditLogRepo }: CreateAuditLogServiceInput): AuditLogService => {
+  return {
+    async logAuthorizationGrant({ operator, teacherId, grantType, targetId }: LogAuthorizationAuditInput) {
+      await auditLogRepo.createAuditLog({
+        operator: normalizeOperator(operator),
+        action: "authorization_grant",
+        target: createAuditTarget(grantType, targetId),
+        detail: `teacher:${teacherId}`,
+        createdAt: new Date()
+      });
+    },
+
+    async logAuthorizationRevoke({ operator, teacherId, grantType, targetId }: LogAuthorizationAuditInput) {
+      await auditLogRepo.createAuditLog({
+        operator: normalizeOperator(operator),
+        action: "authorization_revoke",
+        target: createAuditTarget(grantType, targetId),
+        detail: `teacher:${teacherId}`,
+        createdAt: new Date()
+      });
+    },
+
+    async logPasswordReset({ operator, studentId }: LogPasswordResetAuditInput) {
+      await auditLogRepo.createAuditLog({
+        operator: normalizeOperator(operator),
+        action: "password_reset",
+        target: createAuditTarget("student", studentId),
+        detail: null,
+        createdAt: new Date()
+      });
+    },
+
+    async logActivityPublish({ operator, activityType, activityTitle }: LogActivityPublishAuditInput) {
+      await auditLogRepo.createAuditLog({
+        operator: normalizeOperator(operator),
+        action: "activity_publish",
+        target: createAuditTarget(activityType, normalizeTitle(activityTitle)),
+        detail: null,
+        createdAt: new Date()
+      });
+    }
+  };
+};

--- a/src/modules/authorization/grant-service.ts
+++ b/src/modules/authorization/grant-service.ts
@@ -1,0 +1,47 @@
+export type GrantType = "student" | "class";
+
+export interface AuthorizationGrantInput {
+  grantType: GrantType;
+  teacherId: string;
+  targetId: number;
+}
+
+export interface AuthorizationGrantRepository {
+  assignStudentGrant(teacherId: string, studentId: number): Promise<void>;
+  revokeStudentGrant(teacherId: string, studentId: number): Promise<void>;
+  assignClassGrant(teacherId: string, classId: number): Promise<void>;
+  revokeClassGrant(teacherId: string, classId: number): Promise<void>;
+}
+
+export interface AuthorizationGrantService {
+  assignGrant(input: AuthorizationGrantInput): Promise<void>;
+  revokeGrant(input: AuthorizationGrantInput): Promise<void>;
+}
+
+export interface CreateAuthorizationGrantServiceInput {
+  authorizationGrantRepo: AuthorizationGrantRepository;
+}
+
+export const createAuthorizationGrantService = ({
+  authorizationGrantRepo
+}: CreateAuthorizationGrantServiceInput): AuthorizationGrantService => {
+  return {
+    async assignGrant({ grantType, teacherId, targetId }: AuthorizationGrantInput): Promise<void> {
+      if (grantType === "student") {
+        await authorizationGrantRepo.assignStudentGrant(teacherId, targetId);
+        return;
+      }
+
+      await authorizationGrantRepo.assignClassGrant(teacherId, targetId);
+    },
+
+    async revokeGrant({ grantType, teacherId, targetId }: AuthorizationGrantInput): Promise<void> {
+      if (grantType === "student") {
+        await authorizationGrantRepo.revokeStudentGrant(teacherId, targetId);
+        return;
+      }
+
+      await authorizationGrantRepo.revokeClassGrant(teacherId, targetId);
+    }
+  };
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,4 +1,7 @@
 import { Hono } from "hono";
+import type { ActivityService, ActivityType } from "../modules/activity/service.js";
+import type { AuditLogService } from "../modules/audit/service.js";
+import type { AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
 import {
   InvalidNewPasswordError,
   StudentNotFoundError,
@@ -9,8 +12,25 @@ interface AdminResetPasswordRequestBody {
   newPassword: string;
 }
 
+interface AdminGrantRequestBody {
+  grantType: GrantType;
+  teacherId: string;
+  targetId: number;
+}
+
+interface AdminPublishActivityRequestBody {
+  activityType: ActivityType;
+  title: string;
+}
+
 export interface AdminRouteDependencies {
   studentAuthService: Pick<StudentAuthService, "resetStudentPasswordByAdmin">;
+  authorizationGrantService: Pick<AuthorizationGrantService, "assignGrant" | "revokeGrant">;
+  activityService: Pick<ActivityService, "publishActivity">;
+  auditLogService: Pick<
+    AuditLogService,
+    "logAuthorizationGrant" | "logAuthorizationRevoke" | "logPasswordReset" | "logActivityPublish"
+  >;
   adminApiKey: string;
 }
 
@@ -24,7 +44,11 @@ const isValidResetPasswordBody = (body: unknown): body is AdminResetPasswordRequ
   return typeof newPassword === "string";
 };
 
-const parseStudentId = (rawId: string): number | null => {
+const isValidGrantType = (grantType: unknown): grantType is GrantType => {
+  return grantType === "student" || grantType === "class";
+};
+
+const parsePositiveInteger = (rawId: string): number | null => {
   if (!/^[1-9]\d*$/.test(rawId)) {
     return null;
   }
@@ -38,19 +62,71 @@ const parseStudentId = (rawId: string): number | null => {
   return parsed;
 };
 
+const parseTargetId = (rawTargetId: unknown): number | null => {
+  if (typeof rawTargetId !== "number" || !Number.isInteger(rawTargetId) || rawTargetId <= 0) {
+    return null;
+  }
+
+  return rawTargetId;
+};
+
+const isValidGrantBody = (body: unknown): body is AdminGrantRequestBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const grantType = (body as { grantType?: unknown }).grantType;
+  const teacherId = (body as { teacherId?: unknown }).teacherId;
+  const targetId = parseTargetId((body as { targetId?: unknown }).targetId);
+
+  return isValidGrantType(grantType) && typeof teacherId === "string" && teacherId.trim().length > 0 && !!targetId;
+};
+
+const isValidActivityType = (activityType: unknown): activityType is ActivityType => {
+  return activityType === "course" || activityType === "competition" || activityType === "project";
+};
+
+const isValidPublishActivityBody = (body: unknown): body is AdminPublishActivityRequestBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const activityType = (body as { activityType?: unknown }).activityType;
+  const title = (body as { title?: unknown }).title;
+
+  return isValidActivityType(activityType) && typeof title === "string" && title.trim().length > 0;
+};
+
+const isForbiddenByAdminKey = (requestAdminKey: string | undefined, adminApiKey: string): boolean => {
+  return !requestAdminKey || requestAdminKey !== adminApiKey;
+};
+
+const resolveOperator = (rawOperator: string | undefined): string => {
+  if (!rawOperator) {
+    return "system-admin";
+  }
+
+  const operator = rawOperator.trim();
+  return operator.length > 0 ? operator : "system-admin";
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
+  authorizationGrantService,
+  activityService,
+  auditLogService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
 
   admin.post("/students/:id/reset-password", async (c) => {
     const requestAdminKey = c.req.header("x-admin-key");
-    if (!requestAdminKey || requestAdminKey !== adminApiKey) {
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
       return c.json({ message: "forbidden" }, 403);
     }
 
-    const studentId = parseStudentId(c.req.param("id"));
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const studentId = parsePositiveInteger(c.req.param("id"));
 
     if (!studentId) {
       return c.json({ message: "invalid student id" }, 400);
@@ -74,6 +150,11 @@ export const createAdminRoutes = ({
         newPassword: body.newPassword
       });
 
+      await auditLogService.logPasswordReset({
+        operator,
+        studentId
+      });
+
       return c.json({ message: "password reset" }, 200);
     } catch (error) {
       if (error instanceof InvalidNewPasswordError) {
@@ -86,6 +167,109 @@ export const createAdminRoutes = ({
 
       throw error;
     }
+  });
+
+  admin.post("/authorizations/grants", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidGrantBody(body)) {
+      return c.json({ message: "grantType/teacherId/targetId is required" }, 400);
+    }
+
+    await authorizationGrantService.assignGrant({
+      grantType: body.grantType,
+      teacherId: body.teacherId.trim(),
+      targetId: body.targetId
+    });
+
+    await auditLogService.logAuthorizationGrant({
+      operator,
+      teacherId: body.teacherId.trim(),
+      grantType: body.grantType,
+      targetId: body.targetId
+    });
+
+    return c.json({ message: "authorization granted" }, 200);
+  });
+
+  admin.delete("/authorizations/grants", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidGrantBody(body)) {
+      return c.json({ message: "grantType/teacherId/targetId is required" }, 400);
+    }
+
+    await authorizationGrantService.revokeGrant({
+      grantType: body.grantType,
+      teacherId: body.teacherId.trim(),
+      targetId: body.targetId
+    });
+
+    await auditLogService.logAuthorizationRevoke({
+      operator,
+      teacherId: body.teacherId.trim(),
+      grantType: body.grantType,
+      targetId: body.targetId
+    });
+
+    return c.json({ message: "authorization revoked" }, 200);
+  });
+
+  admin.post("/activities", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidPublishActivityBody(body)) {
+      return c.json({ message: "activityType/title is required" }, 400);
+    }
+
+    await activityService.publishActivity({
+      activityType: body.activityType,
+      title: body.title.trim()
+    });
+
+    await auditLogService.logActivityPublish({
+      operator,
+      activityType: body.activityType,
+      activityTitle: body.title.trim()
+    });
+
+    return c.json({ message: "activity published" }, 201);
   });
 
   return admin;

--- a/tests/audit/audit-service.test.ts
+++ b/tests/audit/audit-service.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createAuditLogService,
+  type AuditLogRepository,
+  type PersistAuditLogInput
+} from "../../src/modules/audit/service.ts";
+
+interface AuditFixture {
+  logs: PersistAuditLogInput[];
+}
+
+const createRepository = (fixture: AuditFixture): AuditLogRepository => ({
+  async createAuditLog(input) {
+    fixture.logs.push(input);
+  }
+});
+
+test("audit service should write logs for grant/revoke/reset/publish with operator target action time", async () => {
+  const fixture: AuditFixture = {
+    logs: []
+  };
+
+  const service = createAuditLogService({
+    auditLogRepo: createRepository(fixture)
+  });
+
+  await service.logAuthorizationGrant({
+    operator: "admin-1",
+    teacherId: "teacher-101",
+    grantType: "student",
+    targetId: 11
+  });
+
+  await service.logAuthorizationRevoke({
+    operator: "admin-1",
+    teacherId: "teacher-101",
+    grantType: "class",
+    targetId: 22
+  });
+
+  await service.logPasswordReset({
+    operator: "admin-2",
+    studentId: 2002
+  });
+
+  await service.logActivityPublish({
+    operator: "admin-3",
+    activityType: "course",
+    activityTitle: "就业指导课"
+  });
+
+  assert.equal(fixture.logs.length, 4);
+
+  for (const log of fixture.logs) {
+    assert.ok(log.operator.length > 0);
+    assert.ok(log.target.length > 0);
+    assert.ok(log.action.length > 0);
+    assert.ok(log.createdAt instanceof Date);
+  }
+
+  assert.equal(fixture.logs[0].action, "authorization_grant");
+  assert.equal(fixture.logs[1].action, "authorization_revoke");
+  assert.equal(fixture.logs[2].action, "password_reset");
+  assert.equal(fixture.logs[3].action, "activity_publish");
+});

--- a/tests/auth/admin-audit-operations.test.ts
+++ b/tests/auth/admin-audit-operations.test.ts
@@ -1,0 +1,132 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+import type { PublishActivityInput } from "../../src/modules/activity/service.ts";
+import type { AuthorizationGrantInput } from "../../src/modules/authorization/grant-service.ts";
+
+interface OperationFixture {
+  assigned: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number }>;
+  revoked: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number }>;
+  published: Array<{ activityType: "course" | "competition" | "project"; title: string }>;
+  auditActions: string[];
+}
+
+const adminApiKey = "admin-secret-key";
+
+const buildApp = (fixture: OperationFixture) => {
+  const app = new Hono();
+
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      adminApiKey,
+      authorizationGrantService: {
+        async assignGrant(input: AuthorizationGrantInput) {
+          fixture.assigned.push(input);
+        },
+        async revokeGrant(input: AuthorizationGrantInput) {
+          fixture.revoked.push(input);
+        }
+      },
+      activityService: {
+        async publishActivity(input: PublishActivityInput) {
+          fixture.published.push(input);
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          fixture.auditActions.push("authorization_grant");
+        },
+        async logAuthorizationRevoke() {
+          fixture.auditActions.push("authorization_revoke");
+        },
+        async logPasswordReset() {
+          fixture.auditActions.push("password_reset");
+        },
+        async logActivityPublish() {
+          fixture.auditActions.push("activity_publish");
+        }
+      }
+    })
+  );
+
+  return app;
+};
+
+test("admin authorization grant/revoke endpoints should write audit logs", async () => {
+  const fixture: OperationFixture = {
+    assigned: [],
+    revoked: [],
+    published: [],
+    auditActions: []
+  };
+  const app = buildApp(fixture);
+
+  const grantRes = await app.request("/admin/authorizations/grants", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-001"
+    },
+    body: JSON.stringify({
+      grantType: "student",
+      teacherId: "teacher-1",
+      targetId: 1001
+    })
+  });
+
+  assert.equal(grantRes.status, 200);
+
+  const revokeRes = await app.request("/admin/authorizations/grants", {
+    method: "DELETE",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-001"
+    },
+    body: JSON.stringify({
+      grantType: "student",
+      teacherId: "teacher-1",
+      targetId: 1001
+    })
+  });
+
+  assert.equal(revokeRes.status, 200);
+  assert.equal(fixture.assigned.length, 1);
+  assert.equal(fixture.revoked.length, 1);
+  assert.deepEqual(fixture.auditActions, ["authorization_grant", "authorization_revoke"]);
+});
+
+test("admin activity publish endpoint should write audit log", async () => {
+  const fixture: OperationFixture = {
+    assigned: [],
+    revoked: [],
+    published: [],
+    auditActions: []
+  };
+  const app = buildApp(fixture);
+
+  const publishRes = await app.request("/admin/activities", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-002"
+    },
+    body: JSON.stringify({
+      activityType: "course",
+      title: "就业指导课"
+    })
+  });
+
+  assert.equal(publishRes.status, 201);
+  assert.equal(fixture.published.length, 1);
+  assert.deepEqual(fixture.auditActions, ["activity_publish"]);
+});

--- a/tests/auth/admin-reset-password.test.ts
+++ b/tests/auth/admin-reset-password.test.ts
@@ -14,6 +14,7 @@ const adminApiKey = "admin-secret-key";
 interface TestContext {
   student: StudentAuthRecord | null;
   updateInputs: StudentPasswordUpdateInput[];
+  auditActions: string[];
 }
 
 function buildStudentRepo(ctx: TestContext): StudentAuthRepository {
@@ -60,6 +61,33 @@ function buildApp(ctx: TestContext): Hono {
     "/admin",
     createAdminRoutes({
       studentAuthService: service,
+      authorizationGrantService: {
+        async assignGrant() {
+          return;
+        },
+        async revokeGrant() {
+          return;
+        }
+      },
+      activityService: {
+        async publishActivity() {
+          return;
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          ctx.auditActions.push("authorization_grant");
+        },
+        async logAuthorizationRevoke() {
+          ctx.auditActions.push("authorization_revoke");
+        },
+        async logPasswordReset() {
+          ctx.auditActions.push("password_reset");
+        },
+        async logActivityPublish() {
+          ctx.auditActions.push("activity_publish");
+        }
+      },
       adminApiKey
     })
   );
@@ -75,7 +103,8 @@ test("POST /admin/students/:id/reset-password should return 403 when X-Admin-Key
       passwordHash: "old-hash",
       mustChangePassword: false
     },
-    updateInputs: []
+    updateInputs: [],
+    auditActions: []
   };
 
   const app = buildApp(ctx);
@@ -111,6 +140,7 @@ test("POST /admin/students/:id/reset-password should return 403 when X-Admin-Key
     message: "forbidden"
   });
   assert.equal(ctx.updateInputs.length, 0);
+  assert.deepEqual(ctx.auditActions, []);
 });
 
 test("POST /admin/students/:id/reset-password should update password with mustChangePassword=true when admin key is valid", async () => {
@@ -121,7 +151,8 @@ test("POST /admin/students/:id/reset-password should update password with mustCh
       passwordHash: "old-hash",
       mustChangePassword: false
     },
-    updateInputs: []
+    updateInputs: [],
+    auditActions: []
   };
 
   const app = buildApp(ctx);
@@ -149,12 +180,14 @@ test("POST /admin/students/:id/reset-password should update password with mustCh
   assert.equal(updateInput.passwordHash, "hashed:ResetPass123!");
   assert.equal(updateInput.mustChangePassword, true);
   assert.ok(updateInput.passwordUpdatedAt instanceof Date);
+  assert.deepEqual(ctx.auditActions, ["password_reset"]);
 });
 
 test("POST /admin/students/:id/reset-password should return 404 when student does not exist", async () => {
   const ctx: TestContext = {
     student: null,
-    updateInputs: []
+    updateInputs: [],
+    auditActions: []
   };
 
   const app = buildApp(ctx);
@@ -176,6 +209,7 @@ test("POST /admin/students/:id/reset-password should return 404 when student doe
   });
 
   assert.equal(ctx.updateInputs.length, 0);
+  assert.deepEqual(ctx.auditActions, []);
 });
 
 test("POST /admin/students/:id/reset-password should return 400 when newPassword is blank or too short", async () => {
@@ -187,7 +221,8 @@ test("POST /admin/students/:id/reset-password should return 400 when newPassword
         passwordHash: "old-hash",
         mustChangePassword: false
       },
-      updateInputs: []
+      updateInputs: [],
+      auditActions: []
     };
 
     const app = buildApp(ctx);
@@ -208,6 +243,7 @@ test("POST /admin/students/:id/reset-password should return 400 when newPassword
       message: "newPassword is required and must be at least 8 characters"
     });
     assert.equal(ctx.updateInputs.length, 0);
+    assert.deepEqual(ctx.auditActions, []);
   }
 });
 
@@ -219,7 +255,8 @@ test("POST /admin/students/:id/reset-password should reject non-integer student 
       passwordHash: "old-hash",
       mustChangePassword: false
     },
-    updateInputs: []
+    updateInputs: [],
+    auditActions: []
   };
 
   const app = buildApp(ctx);
@@ -240,4 +277,5 @@ test("POST /admin/students/:id/reset-password should reject non-integer student 
     message: "invalid student id"
   });
   assert.equal(ctx.updateInputs.length, 0);
+  assert.deepEqual(ctx.auditActions, []);
 });

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,26 +18,26 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 4, "journal should contain at least 4 entries");
+  assert.ok(entries.length >= 5, "journal should contain at least 5 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
     );
   }
 
-  const snapshot0002 = readJson(path.join(drizzleMetaDir, "0002_snapshot.json"));
   const snapshot0003 = readJson(path.join(drizzleMetaDir, "0003_snapshot.json"));
+  const snapshot0004 = readJson(path.join(drizzleMetaDir, "0004_snapshot.json"));
 
   assert.equal(
-    snapshot0003.prevId,
-    snapshot0002.id,
-    "0003 snapshot prevId should point to 0002 snapshot id"
+    snapshot0004.prevId,
+    snapshot0003.id,
+    "0004 snapshot prevId should point to 0003 snapshot id"
   );
 });
 
@@ -82,6 +82,23 @@ test("0003 migration file should exist and include resource authorization tables
       migrationSql,
       new RegExp(`CREATE TABLE\\s+\`${tableName}\``, "i"),
       `0003 migration should create table ${tableName}`
+    );
+  }
+});
+
+test("0004 migration file should exist and include activity and audit log tables", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0004 = migrationFiles.find((fileName) => /^0004_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0004, "expected a 0004 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0004), "utf8");
+
+  for (const tableName of ["activities", "audit_logs"]) {
+    assert.match(
+      migrationSql,
+      new RegExp(`CREATE TABLE\\s+\`${tableName}\``, "i"),
+      `0004 migration should create table ${tableName}`
     );
   }
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1,7 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  activities,
   authScopes,
+  auditLogs,
   certificates,
   profiles,
   reports,
@@ -52,4 +54,17 @@ test("schema should include resource and grant authorization tables", () => {
   assert.equal(profiles.studentId.name, "student_id");
   assert.equal(teacherStudentGrants.teacherId.name, "teacher_id");
   assert.equal(teacherClassGrants.classId.name, "class_id");
+});
+
+test("schema should include activity and audit log tables", () => {
+  assert.equal(activities[Symbol.for("drizzle:Name")], "activities");
+  assert.equal(auditLogs[Symbol.for("drizzle:Name")], "audit_logs");
+
+  assert.equal(activities.activityType.name, "activity_type");
+  assert.equal(activities.title.name, "title");
+
+  assert.equal(auditLogs.operator.name, "operator");
+  assert.equal(auditLogs.action.name, "action");
+  assert.equal(auditLogs.target.name, "target");
+  assert.equal(auditLogs.createdAt.name, "created_at");
 });


### PR DESCRIPTION
## 背景
实现 B04：授权与关键操作审计日志。

## 变更内容
- 新增审计日志服务：`src/modules/audit/service.ts`
  - 统一记录 `operator/action/target/createdAt`
  - 覆盖动作：`authorization_grant`、`authorization_revoke`、`password_reset`、`activity_publish`
- 新增关键操作服务：
  - `src/modules/authorization/grant-service.ts`
  - `src/modules/activity/service.ts`
- 扩展管理员路由：`src/routes/admin.ts`
  - `POST /admin/students/:id/reset-password`（接入审计）
  - `POST /admin/authorizations/grants`
  - `DELETE /admin/authorizations/grants`
  - `POST /admin/activities`
- 扩展数据模型与迁移：
  - 新增表：`activities`、`audit_logs`
  - 迁移：`drizzle/0004_conscious_hex.sql`
- 新增/更新测试：
  - `tests/audit/audit-service.test.ts`
  - `tests/auth/admin-audit-operations.test.ts`
  - `tests/auth/admin-reset-password.test.ts`
  - `tests/db/schema.test.ts`
  - `tests/db/migrations.test.ts`

## 验证
- [x] `npm test`（36 passed）
- [x] `npm run check`
- [x] `npm run build`

Closes #6
