### PR TITLE
feat: 完成 B05 打卡凭证文件上传能力

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 .DS_Store
 drizzle.config.js
+uploads

--- a/docs/plans/2026-03-01-b05-certificate-upload-design.md
+++ b/docs/plans/2026-03-01-b05-certificate-upload-design.md
@@ -1,0 +1,54 @@
+# B05 打卡凭证文件上传设计
+
+## 任务
+Issue #7（B05）：实现打卡凭证文件上传能力（图片/文件），支持白名单与大小限制，返回可追踪 fileId，非法格式拒绝。
+
+## 已确认约束
+- 存储方式：本地磁盘目录
+- 白名单：jpg/jpeg/png/pdf/doc/docx
+- 大小限制：10MB
+- 鉴权：必须校验学生登录态（Bearer token）
+- 成功返回：仅返回 `fileId`
+
+## API 设计
+- `POST /student/certificates/upload`
+- Header：`Authorization: Bearer <token>`
+- Body：`multipart/form-data`，字段 `file`
+
+### 返回语义
+- 200：`{ "fileId": "..." }`
+- 400：请求体非法或缺少文件
+- 401：未登录或登录态无效
+- 413：文件超过 10MB
+- 415：文件格式不在白名单
+
+## 数据模型
+新增 `certificate_files`：
+- `id` int pk
+- `file_id` varchar(64) unique
+- `student_id` int fk -> students.id
+- `original_name` varchar(255)
+- `mime_type` varchar(128)
+- `size_bytes` int
+- `storage_path` varchar(255)
+- `created_at` timestamp
+
+## 落盘策略
+- 目录：`uploads/certificates/`
+- 文件名：`<fileId>.<ext>`
+- 若写盘成功但入库失败：删除已写入文件（回滚）
+
+## 模块拆分
+- `src/modules/upload/certificate-upload.ts`
+  - 校验格式/大小
+  - 生成 fileId
+  - 写入磁盘
+  - 调用 repo 写入元数据
+- `src/routes/student.ts`
+  - 学生上传路由
+  - 映射错误到 HTTP 状态码
+
+## 验收映射
+- 白名单与大小限制 ✅
+- 返回可追踪 fileId ✅
+- 非法格式拒绝并提示 ✅

--- a/docs/plans/2026-03-01-b05-certificate-upload.md
+++ b/docs/plans/2026-03-01-b05-certificate-upload.md
@@ -1,0 +1,57 @@
+# B05 Certificate Upload Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 为学生打卡凭证实现受鉴权保护的文件上传接口，支持格式/大小校验并返回 fileId。
+
+**Architecture:** 使用“上传服务 + 学生路由 + 元数据表”三层结构。路由负责鉴权与状态码映射，服务负责文件校验、落盘和元数据入库。
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM, Node fs/promises
+
+---
+
+### Task 1: 上传接口测试（RED）
+
+**Files:**
+- Create: `tests/upload/certificate-upload.test.ts`
+
+**Step 1:** 写未登录、缺文件、非法格式、超大小、成功上传测试。
+**Step 2:** 跑定向测试确认 RED。
+
+### Task 2: 上传服务实现（GREEN）
+
+**Files:**
+- Create: `src/modules/upload/certificate-upload.ts`
+
+**Step 1:** 实现格式/大小校验与 fileId 生成。
+**Step 2:** 实现磁盘写入与失败回滚。
+
+### Task 3: 路由接入与索引装配
+
+**Files:**
+- Create: `src/routes/student.ts`
+- Modify: `src/index.ts`
+
+**Step 1:** 新增 `/student/certificates/upload`。
+**Step 2:** 挂载 `requireStudentAuth`，接入上传服务。
+
+### Task 4: 数据模型与迁移
+
+**Files:**
+- Modify: `src/db/schema.ts`
+- Create: `drizzle/0005_*.sql`
+- Modify: `drizzle/meta/*`
+- Modify: `tests/db/schema.test.ts`
+- Modify: `tests/db/migrations.test.ts`
+
+**Step 1:** 新增 `certificate_files` 表。
+**Step 2:** 生成迁移并补测试断言。
+
+### Task 5: 回归与收口
+
+**Files:**
+- Modify: `.gitignore`
+
+**Step 1:** 忽略 `uploads/` 目录。
+**Step 2:** 执行 `npm test && npm run check && npm run build`。
+**Step 3:** 提交、推送、Issue 回写、PR。

--- a/drizzle/0005_flashy_unus.sql
+++ b/drizzle/0005_flashy_unus.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `certificate_files` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`file_id` varchar(64) NOT NULL,
+	`student_id` int NOT NULL,
+	`original_name` varchar(255) NOT NULL,
+	`mime_type` varchar(128) NOT NULL,
+	`size_bytes` int NOT NULL,
+	`storage_path` varchar(255) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `certificate_files_id` PRIMARY KEY(`id`),
+	CONSTRAINT `certificate_files_file_id_unique` UNIQUE(`file_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `certificate_files` ADD CONSTRAINT `certificate_files_student_id_students_id_fk` FOREIGN KEY (`student_id`) REFERENCES `students`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `certificate_files_student_id_idx` ON `certificate_files` (`student_id`);--> statement-breakpoint
+CREATE INDEX `certificate_files_created_at_idx` ON `certificate_files` (`created_at`);

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1254 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "d5ea832f-7ffe-4212-bd2b-51450053829b",
+  "prevId": "f82f8f72-1eaa-47bd-94ea-cc3070ab562b",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "enum('course','competition','project')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "activities_activity_type_idx": {
+          "name": "activities_activity_type_idx",
+          "columns": [
+            "activity_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activities_id": {
+          "name": "activities_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('authorization_grant','authorization_revoke','password_reset','activity_publish')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_operator_idx": {
+          "name": "audit_logs_operator_idx",
+          "columns": [
+            "operator"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_target_idx": {
+          "name": "audit_logs_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "auth_scopes": {
+      "name": "auth_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "enum('school','college','class','student')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "auth_scopes_school_id_idx": {
+          "name": "auth_scopes_school_id_idx",
+          "columns": [
+            "school_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_college_id_idx": {
+          "name": "auth_scopes_college_id_idx",
+          "columns": [
+            "college_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_class_id_idx": {
+          "name": "auth_scopes_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_student_id_idx": {
+          "name": "auth_scopes_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_scopes_school_id_schools_id_fk": {
+          "name": "auth_scopes_school_id_schools_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_college_id_colleges_id_fk": {
+          "name": "auth_scopes_college_id_colleges_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_class_id_classes_id_fk": {
+          "name": "auth_scopes_class_id_classes_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_student_id_students_id_fk": {
+          "name": "auth_scopes_student_id_students_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_scopes_id": {
+          "name": "auth_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "certificate_files": {
+      "name": "certificate_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "certificate_files_file_id_unique": {
+          "name": "certificate_files_file_id_unique",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": true
+        },
+        "certificate_files_student_id_idx": {
+          "name": "certificate_files_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        },
+        "certificate_files_created_at_idx": {
+          "name": "certificate_files_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificate_files_student_id_students_id_fk": {
+          "name": "certificate_files_student_id_students_id_fk",
+          "tableFrom": "certificate_files",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificate_files_id": {
+          "name": "certificate_files_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "certificates_student_id_idx": {
+          "name": "certificates_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_student_id_students_id_fk": {
+          "name": "certificates_student_id_students_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "classes": {
+      "name": "classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "classes_college_id_name_unique": {
+          "name": "classes_college_id_name_unique",
+          "columns": [
+            "college_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "classes_college_id_colleges_id_fk": {
+          "name": "classes_college_id_colleges_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "classes_id": {
+          "name": "classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "colleges": {
+      "name": "colleges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "colleges_school_id_name_unique": {
+          "name": "colleges_school_id_name_unique",
+          "columns": [
+            "school_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "colleges_school_id_schools_id_fk": {
+          "name": "colleges_school_id_schools_id_fk",
+          "tableFrom": "colleges",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "colleges_id": {
+          "name": "colleges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "profiles_student_id_idx": {
+          "name": "profiles_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_student_id_students_id_fk": {
+          "name": "profiles_student_id_students_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profiles_id": {
+          "name": "profiles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "reports_student_id_idx": {
+          "name": "reports_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_student_id_students_id_fk": {
+          "name": "reports_student_id_students_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reports_id": {
+          "name": "reports_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "role_scopes": {
+      "name": "role_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "role_scopes_role_id_scope_id_unique": {
+          "name": "role_scopes_role_id_scope_id_unique",
+          "columns": [
+            "role_id",
+            "scope_id"
+          ],
+          "isUnique": true
+        },
+        "role_scopes_role_id_idx": {
+          "name": "role_scopes_role_id_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_scopes_scope_id_idx": {
+          "name": "role_scopes_scope_id_idx",
+          "columns": [
+            "scope_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_scopes_role_id_roles_id_fk": {
+          "name": "role_scopes_role_id_roles_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_scopes_scope_id_auth_scopes_id_fk": {
+          "name": "role_scopes_scope_id_auth_scopes_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "auth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_scopes_id": {
+          "name": "role_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "enum('student','teacher','admin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "roles_code_unique": {
+          "name": "roles_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "roles_id": {
+          "name": "roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schools": {
+      "name": "schools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schools_id": {
+          "name": "schools_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "students": {
+      "name": "students",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_no": {
+          "name": "student_no",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "password_updated_at": {
+          "name": "password_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "students_student_no_unique": {
+          "name": "students_student_no_unique",
+          "columns": [
+            "student_no"
+          ],
+          "isUnique": true
+        },
+        "students_class_id_idx": {
+          "name": "students_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "students_class_id_classes_id_fk": {
+          "name": "students_class_id_classes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "students_id": {
+          "name": "students_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tasks_student_id_idx": {
+          "name": "tasks_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_student_id_students_id_fk": {
+          "name": "tasks_student_id_students_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id": {
+          "name": "tasks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_class_grants": {
+      "name": "teacher_class_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_class_grants_teacher_class_unique": {
+          "name": "teacher_class_grants_teacher_class_unique",
+          "columns": [
+            "teacher_id",
+            "class_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_class_grants_teacher_id_idx": {
+          "name": "teacher_class_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_class_grants_class_id_idx": {
+          "name": "teacher_class_grants_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_class_grants_class_id_classes_id_fk": {
+          "name": "teacher_class_grants_class_id_classes_id_fk",
+          "tableFrom": "teacher_class_grants",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_class_grants_id": {
+          "name": "teacher_class_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_student_grants": {
+      "name": "teacher_student_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_student_grants_teacher_student_unique": {
+          "name": "teacher_student_grants_teacher_student_unique",
+          "columns": [
+            "teacher_id",
+            "student_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_student_grants_teacher_id_idx": {
+          "name": "teacher_student_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_student_grants_student_id_idx": {
+          "name": "teacher_student_grants_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_student_grants_student_id_students_id_fk": {
+          "name": "teacher_student_grants_student_id_students_id_fk",
+          "tableFrom": "teacher_student_grants",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_grants_id": {
+          "name": "teacher_student_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1772376427694,
       "tag": "0004_conscious_hex",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "5",
+      "when": 1772377359808,
+      "tag": "0005_flashy_unus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -107,6 +107,27 @@ export const certificates = mysqlTable(
   })
 );
 
+export const certificateFiles = mysqlTable(
+  "certificate_files",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    fileId: varchar("file_id", { length: 64 }).notNull(),
+    studentId: int("student_id")
+      .notNull()
+      .references(() => students.id),
+    originalName: varchar("original_name", { length: 255 }).notNull(),
+    mimeType: varchar("mime_type", { length: 128 }).notNull(),
+    sizeBytes: int("size_bytes").notNull(),
+    storagePath: varchar("storage_path", { length: 255 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    fileIdUnique: uniqueIndex("certificate_files_file_id_unique").on(table.fileId),
+    studentIdIdx: index("certificate_files_student_id_idx").on(table.studentId),
+    createdAtIdx: index("certificate_files_created_at_idx").on(table.createdAt)
+  })
+);
+
 export const profiles = mysqlTable(
   "profiles",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 import { serve } from "@hono/node-server";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
+import path from "node:path";
 import { env } from "./config/env.js";
 import { db } from "./db/client.js";
 import {
   activities,
   auditLogs,
+  certificateFiles,
   certificates,
   profiles,
   reports,
@@ -23,10 +25,12 @@ import { createResourceAuthorizationService, type ResourceType } from "./modules
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
+import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
 import { createAdminRoutes } from "./routes/admin.js";
 import { createAuthRoutes } from "./routes/auth.js";
 import healthRoutes from "./routes/health.js";
 import { createResourcesRoutes } from "./routes/resources.js";
+import { createStudentRoutes } from "./routes/student.js";
 
 const studentRepo = {
   async findStudentByNo(studentNo: string) {
@@ -264,6 +268,41 @@ const auditLogService = createAuditLogService({
   auditLogRepo
 });
 
+const certificateFileRepo = {
+  async createCertificateFile({
+    fileId,
+    studentId,
+    originalName,
+    mimeType,
+    sizeBytes,
+    storagePath,
+    createdAt
+  }: {
+    fileId: string;
+    studentId: number;
+    originalName: string;
+    mimeType: string;
+    sizeBytes: number;
+    storagePath: string;
+    createdAt: Date;
+  }): Promise<void> {
+    await db.insert(certificateFiles).values({
+      fileId,
+      studentId,
+      originalName,
+      mimeType,
+      sizeBytes,
+      storagePath,
+      createdAt
+    });
+  }
+};
+
+const certificateUploadService = createCertificateUploadService({
+  certificateFileRepo,
+  uploadDir: path.resolve(process.cwd(), "uploads/certificates")
+});
+
 const createResourceAuthorization = (resourceType: ResourceType) =>
   createResourceAuthorizationMiddleware({
     resourceType,
@@ -292,6 +331,7 @@ app.route(
   })
 );
 app.route("/resources", createResourcesRoutes({ createResourceAuthorization }));
+app.route("/student", createStudentRoutes({ requireStudentAuth, certificateUploadService }));
 
 serve(
   {

--- a/src/modules/upload/certificate-upload.ts
+++ b/src/modules/upload/certificate-upload.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const DEFAULT_MAX_CERTIFICATE_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+const SUPPORTED_EXTENSIONS = new Set(["jpg", "jpeg", "png", "pdf", "doc", "docx"]);
+
+export interface UploadedFile {
+  name: string;
+  type: string;
+  size: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface PersistCertificateFileInput {
+  fileId: string;
+  studentId: number;
+  originalName: string;
+  mimeType: string;
+  sizeBytes: number;
+  storagePath: string;
+  createdAt: Date;
+}
+
+export interface CertificateFileRepository {
+  createCertificateFile(input: PersistCertificateFileInput): Promise<void>;
+}
+
+export interface UploadCertificateInput {
+  studentId: number;
+  file?: UploadedFile | null;
+}
+
+export interface UploadCertificateResult {
+  fileId: string;
+}
+
+export interface CertificateUploadService {
+  uploadCertificate(input: UploadCertificateInput): Promise<UploadCertificateResult>;
+}
+
+export interface CreateCertificateUploadServiceInput {
+  certificateFileRepo: CertificateFileRepository;
+  uploadDir: string;
+  maxSizeBytes?: number;
+}
+
+export class MissingUploadFileError extends Error {
+  constructor() {
+    super("file is required");
+    this.name = "MissingUploadFileError";
+  }
+}
+
+export class InvalidFileTypeError extends Error {
+  constructor() {
+    super("unsupported file type");
+    this.name = "InvalidFileTypeError";
+  }
+}
+
+export class FileTooLargeError extends Error {
+  constructor() {
+    super("file too large");
+    this.name = "FileTooLargeError";
+  }
+}
+
+const getFileExtension = (fileName: string): string | null => {
+  const extension = path.extname(fileName).replace(".", "").trim().toLowerCase();
+  return extension.length > 0 ? extension : null;
+};
+
+const ensureValidFile = (file: UploadedFile | null | undefined, maxSizeBytes: number): UploadedFile => {
+  if (!file) {
+    throw new MissingUploadFileError();
+  }
+
+  const extension = getFileExtension(file.name);
+  if (!extension || !SUPPORTED_EXTENSIONS.has(extension)) {
+    throw new InvalidFileTypeError();
+  }
+
+  if (!Number.isInteger(file.size) || file.size <= 0 || file.size > maxSizeBytes) {
+    throw new FileTooLargeError();
+  }
+
+  return file;
+};
+
+const createFileId = (): string => {
+  const suffix = randomUUID().replace(/-/g, "").slice(0, 12);
+  return `cert_${Date.now()}_${suffix}`;
+};
+
+export const createCertificateUploadService = ({
+  certificateFileRepo,
+  uploadDir,
+  maxSizeBytes = DEFAULT_MAX_CERTIFICATE_FILE_SIZE_BYTES
+}: CreateCertificateUploadServiceInput): CertificateUploadService => {
+  return {
+    async uploadCertificate({ studentId, file }: UploadCertificateInput): Promise<UploadCertificateResult> {
+      const validatedFile = ensureValidFile(file, maxSizeBytes);
+      const extension = getFileExtension(validatedFile.name) as string;
+      const fileId = createFileId();
+
+      await mkdir(uploadDir, { recursive: true });
+
+      const storedFileName = `${fileId}.${extension}`;
+      const storagePath = path.join(uploadDir, storedFileName);
+      let writtenToDisk = false;
+
+      try {
+        const buffer = Buffer.from(await validatedFile.arrayBuffer());
+        await writeFile(storagePath, buffer);
+        writtenToDisk = true;
+
+        await certificateFileRepo.createCertificateFile({
+          fileId,
+          studentId,
+          originalName: validatedFile.name,
+          mimeType: validatedFile.type,
+          sizeBytes: validatedFile.size,
+          storagePath,
+          createdAt: new Date()
+        });
+
+        return { fileId };
+      } catch (error) {
+        if (writtenToDisk) {
+          await unlink(storagePath).catch(() => undefined);
+        }
+
+        throw error;
+      }
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -1,0 +1,93 @@
+import { Hono, type MiddlewareHandler } from "hono";
+import {
+  FileTooLargeError,
+  InvalidFileTypeError,
+  MissingUploadFileError,
+  type CertificateUploadService,
+  type UploadedFile
+} from "../modules/upload/certificate-upload.js";
+
+export interface StudentRouteDependencies {
+  requireStudentAuth: MiddlewareHandler;
+  certificateUploadService: CertificateUploadService;
+}
+
+const isUploadedFile = (value: unknown): value is UploadedFile => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as {
+    name?: unknown;
+    type?: unknown;
+    size?: unknown;
+    arrayBuffer?: unknown;
+  };
+
+  return (
+    typeof candidate.name === "string" &&
+    typeof candidate.type === "string" &&
+    typeof candidate.size === "number" &&
+    typeof candidate.arrayBuffer === "function"
+  );
+};
+
+const resolveFileFromBody = (body: Record<string, unknown>): UploadedFile | null => {
+  const fileField = body.file;
+
+  if (Array.isArray(fileField)) {
+    return null;
+  }
+
+  return isUploadedFile(fileField) ? fileField : null;
+};
+
+export const createStudentRoutes = ({
+  requireStudentAuth,
+  certificateUploadService
+}: StudentRouteDependencies) => {
+  const student = new Hono();
+
+  student.post("/certificates/upload", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.parseBody({ all: true });
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const file = resolveFileFromBody(body);
+
+    try {
+      const result = await certificateUploadService.uploadCertificate({
+        studentId: studentAuth.studentId,
+        file: file ?? undefined
+      });
+
+      return c.json({ fileId: result.fileId }, 200);
+    } catch (error) {
+      if (error instanceof MissingUploadFileError) {
+        return c.json({ message: "file is required" }, 400);
+      }
+
+      if (error instanceof InvalidFileTypeError) {
+        return c.json({ message: "unsupported file type" }, 415);
+      }
+
+      if (error instanceof FileTooLargeError) {
+        return c.json({ message: "file too large" }, 413);
+      }
+
+      throw error;
+    }
+  });
+
+  return student;
+};
+
+export default createStudentRoutes;

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,26 +18,26 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 5, "journal should contain at least 5 entries");
+  assert.ok(entries.length >= 6, "journal should contain at least 6 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
     );
   }
 
-  const snapshot0003 = readJson(path.join(drizzleMetaDir, "0003_snapshot.json"));
   const snapshot0004 = readJson(path.join(drizzleMetaDir, "0004_snapshot.json"));
+  const snapshot0005 = readJson(path.join(drizzleMetaDir, "0005_snapshot.json"));
 
   assert.equal(
-    snapshot0004.prevId,
-    snapshot0003.id,
-    "0004 snapshot prevId should point to 0003 snapshot id"
+    snapshot0005.prevId,
+    snapshot0004.id,
+    "0005 snapshot prevId should point to 0004 snapshot id"
   );
 });
 
@@ -101,4 +101,19 @@ test("0004 migration file should exist and include activity and audit log tables
       `0004 migration should create table ${tableName}`
     );
   }
+});
+
+test("0005 migration file should exist and include certificate_files table", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0005 = migrationFiles.find((fileName) => /^0005_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0005, "expected a 0005 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0005), "utf8");
+
+  assert.match(
+    migrationSql,
+    /CREATE TABLE\s+`certificate_files`/i,
+    "0005 migration should create table certificate_files"
+  );
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -4,6 +4,7 @@ import {
   activities,
   authScopes,
   auditLogs,
+  certificateFiles,
   certificates,
   profiles,
   reports,
@@ -67,4 +68,14 @@ test("schema should include activity and audit log tables", () => {
   assert.equal(auditLogs.action.name, "action");
   assert.equal(auditLogs.target.name, "target");
   assert.equal(auditLogs.createdAt.name, "created_at");
+});
+
+test("schema should include certificate_files metadata table", () => {
+  assert.equal(certificateFiles[Symbol.for("drizzle:Name")], "certificate_files");
+  assert.equal(certificateFiles.fileId.name, "file_id");
+  assert.equal(certificateFiles.studentId.name, "student_id");
+  assert.equal(certificateFiles.originalName.name, "original_name");
+  assert.equal(certificateFiles.mimeType.name, "mime_type");
+  assert.equal(certificateFiles.sizeBytes.name, "size_bytes");
+  assert.equal(certificateFiles.storagePath.name, "storage_path");
 });

--- a/tests/upload/certificate-upload.test.ts
+++ b/tests/upload/certificate-upload.test.ts
@@ -1,0 +1,190 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { File } from "node:buffer";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createCertificateUploadService,
+  FileTooLargeError,
+  InvalidFileTypeError,
+  type CertificateFileRepository
+} from "../../src/modules/upload/certificate-upload.ts";
+
+const MAX_SIZE_BYTES = 10 * 1024 * 1024;
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+interface UploadFixture {
+  records: Array<{
+    fileId: string;
+    studentId: number;
+    originalName: string;
+    mimeType: string;
+    sizeBytes: number;
+    storagePath: string;
+    createdAt: Date;
+  }>;
+}
+
+const createCertificateFileRepo = (fixture: UploadFixture): CertificateFileRepository => ({
+  async createCertificateFile(input) {
+    fixture.records.push(input);
+  }
+});
+
+const createTestApp = async () => {
+  const fixture: UploadFixture = {
+    records: []
+  };
+
+  const uploadDir = await fs.mkdtemp(path.join(os.tmpdir(), "b05-upload-"));
+
+  const uploadService = createCertificateUploadService({
+    certificateFileRepo: createCertificateFileRepo(fixture),
+    uploadDir,
+    maxSizeBytes: MAX_SIZE_BYTES
+  });
+
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: uploadService
+    })
+  );
+
+  return { app, fixture, uploadDir };
+};
+
+test("certificate upload should return 401 when authorization is missing", async () => {
+  const { app, uploadDir } = await createTestApp();
+
+  const formData = new FormData();
+  formData.append("file", new File([Buffer.from("ok")], "proof.jpg", { type: "image/jpeg" }));
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    body: formData
+  });
+
+  assert.equal(response.status, 401);
+
+  await fs.rm(uploadDir, { recursive: true, force: true });
+});
+
+test("certificate upload should return 400 when file field is missing", async () => {
+  const { app, uploadDir } = await createTestApp();
+
+  const formData = new FormData();
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token"
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { message: "file is required" });
+
+  await fs.rm(uploadDir, { recursive: true, force: true });
+});
+
+test("certificate upload should reject unsupported file type with 415", async () => {
+  const { app, uploadDir } = await createTestApp();
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new File([Buffer.from("hello")], "malware.exe", { type: "application/octet-stream" })
+  );
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token"
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 415);
+  assert.deepEqual(await response.json(), { message: "unsupported file type" });
+
+  await fs.rm(uploadDir, { recursive: true, force: true });
+});
+
+test("certificate upload should reject oversized file with 413", async () => {
+  const { app, uploadDir } = await createTestApp();
+
+  const overLimit = Buffer.alloc(MAX_SIZE_BYTES + 1, 1);
+  const formData = new FormData();
+  formData.append("file", new File([overLimit], "large.pdf", { type: "application/pdf" }));
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token"
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 413);
+  assert.deepEqual(await response.json(), {
+    message: "file too large"
+  });
+
+  await fs.rm(uploadDir, { recursive: true, force: true });
+});
+
+test("certificate upload should return trackable fileId on success", async () => {
+  const { app, fixture, uploadDir } = await createTestApp();
+
+  const formData = new FormData();
+  formData.append("file", new File([Buffer.from("content")], "proof.docx", {
+    type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  }));
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer valid-token"
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { fileId: string };
+
+  assert.ok(body.fileId.startsWith("cert_"));
+  assert.equal(fixture.records.length, 1);
+  assert.equal(fixture.records[0].studentId, 1001);
+
+  const storedPath = fixture.records[0].storagePath;
+  const stat = await fs.stat(storedPath);
+  assert.ok(stat.isFile());
+
+  await fs.rm(uploadDir, { recursive: true, force: true });
+});
+
+// keep imports referenced for explicit behavior assertion
+void FileTooLargeError;
+void InvalidFileTypeError;


### PR DESCRIPTION
## 背景
实现 B05：打卡凭证文件上传能力（图片/文件），要求支持白名单和大小限制，并返回可追踪 fileId。

## 变更内容
- 新增学生上传接口：`POST /student/certificates/upload`
  - 强制校验学生登录态（Bearer token）
  - multipart 文件字段：`file`
  - 返回：`{ fileId }`
- 新增上传服务：`src/modules/upload/certificate-upload.ts`
  - 白名单扩展名：`jpg/jpeg/png/pdf/doc/docx`
  - 文件大小限制：10MB
  - 本地落盘：`uploads/certificates`
  - 入库失败时删除已写文件，避免脏数据
- 扩展数据库：
  - 新增 `certificate_files` 元数据表
  - 迁移文件：`drizzle/0005_flashy_unus.sql`
- 补充测试：
  - `tests/upload/certificate-upload.test.ts`
  - `tests/db/schema.test.ts`
  - `tests/db/migrations.test.ts`
- 其他：
  - `.gitignore` 增加 `uploads`

## 验证
- [x] `npm test`（43 passed）
- [x] `npm run check`
- [x] `npm run build`

Closes #7
