### PR TITLE
feat: 完成 B06 Excel导入与质量校验基础能力

### DIFF
--- a/docs/plans/2026-03-01-b06-excel-import-design.md
+++ b/docs/plans/2026-03-01-b06-excel-import-design.md
@@ -1,0 +1,46 @@
+# B06 Excel 导入与质量校验设计
+
+## 任务
+Issue #8（B06）：实现招生/就业 Excel 导入与质量校验基础能力。
+
+## 已确认约束
+- 仅支持 `.xlsx`
+- 单接口，`datasetType` 区分 `enrollment` / `employment`
+- 本阶段只做校验，不落库
+- 返回 `total/success/failed + errors[]`（行号/字段/原因）
+
+## API 设计
+- `POST /admin/imports/excel/validate`
+- 鉴权：`X-Admin-Key`
+- 请求：`multipart/form-data`
+  - `datasetType`: `enrollment | employment`
+  - `file`: `.xlsx`
+
+### 返回
+- 200: `{ total, success, failed, errors: [{ row, field, reason }] }`
+- 400: 缺少参数/非法 datasetType/缺文件
+- 403: admin key 无效
+- 415: 文件类型不支持
+
+## 校验规则
+通用：
+- 缺失字段（必填为空）
+- 重复学号（同一导入文件内）
+
+招生（enrollment）额外：
+- `score` 必须为 0~750 数值
+- `admissionYear` 必须为 2000~2100 整数
+
+就业（employment）额外：
+- `status` 必须为 `employed|unemployed|further_study|civil_service`
+- `salary` 必须为 >=0 数值
+
+## 实现结构
+- `src/modules/import/excel-validation.ts`：Excel 解析 + 规则校验
+- `src/routes/admin.ts`：新增导入校验路由
+- `src/index.ts`：装配导入服务
+
+## 验收映射
+- 支持 Excel 导入 ✅
+- 识别缺失字段/重复学号/非法值 ✅
+- 返回成功/失败计数 ✅

--- a/docs/plans/2026-03-01-b06-excel-import.md
+++ b/docs/plans/2026-03-01-b06-excel-import.md
@@ -1,0 +1,54 @@
+# B06 Excel Import Validation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 提供统一 Excel 导入校验接口，支持招生/就业两类数据并返回完整质量报告。
+
+**Architecture:** 采用“Admin 路由鉴权 + Import 校验服务”结构。服务负责 `.xlsx` 解析、规则校验和结果汇总，路由负责参数校验与状态码映射。
+
+**Tech Stack:** TypeScript, Hono, SheetJS(xlsx), Node test runner
+
+---
+
+### Task 1: 校验服务测试（RED）
+
+**Files:**
+- Create: `tests/import/excel-validation.test.ts`
+
+**Step 1:** 写缺失字段/重复学号/非法值测试。
+**Step 2:** 跑定向测试确认 RED。
+
+### Task 2: Admin 路由测试（RED）
+
+**Files:**
+- Create: `tests/import/admin-excel-import.test.ts`
+
+**Step 1:** 写 403/400/415/200 场景。
+**Step 2:** 跑定向测试确认 RED。
+
+### Task 3: 实现导入校验服务（GREEN）
+
+**Files:**
+- Create: `src/modules/import/excel-validation.ts`
+- Modify: `package.json` / `package-lock.json`
+
+**Step 1:** 接入 xlsx 读取首个 sheet。
+**Step 2:** 实现 datasetType 分支规则。
+**Step 3:** 输出统计与 errors 明细。
+
+### Task 4: 路由接入
+
+**Files:**
+- Modify: `src/routes/admin.ts`
+- Modify: `src/index.ts`
+
+**Step 1:** 新增 `/admin/imports/excel/validate`。
+**Step 2:** 接入 admin key + 文件类型判断 + 服务调用。
+
+### Task 5: 回归与收口
+
+**Files:**
+- Modify: `README.md`（如需）
+
+**Step 1:** 执行 `npm test && npm run check && npm run build`。
+**Step 2:** 提交、推送、Issue 回写、PR。

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "drizzle-orm": "^0.38.2",
         "hono": "^4.6.15",
         "jsonwebtoken": "^9.0.3",
-        "mysql2": "^3.12.0"
+        "mysql2": "^3.12.0",
+        "xlsx": "^0.18.5"
       },
       "devDependencies": {
         "@types/node": "^22.10.2",
@@ -936,6 +937,15 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/aws-ssl-profiles": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
@@ -966,6 +976,40 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cfb": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
+      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "crc-32": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1220,6 +1264,15 @@
       },
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1562,6 +1615,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
+      }
+    },
+    "node_modules/ssf": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
+      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "frac": "~1.1.2"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tsx": {
@@ -2051,6 +2116,45 @@
       },
       "engines": {
         "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wmf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
+      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/word": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
+      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/xlsx": {
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
+      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "adler-32": "~1.3.0",
+        "cfb": "~1.2.1",
+        "codepage": "~1.15.0",
+        "crc-32": "~1.2.1",
+        "ssf": "~0.11.2",
+        "wmf": "~1.0.1",
+        "word": "~0.3.0"
+      },
+      "bin": {
+        "xlsx": "bin/xlsx.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "drizzle-orm": "^0.38.2",
     "hono": "^4.6.15",
     "jsonwebtoken": "^9.0.3",
-    "mysql2": "^3.12.0"
+    "mysql2": "^3.12.0",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { createResourceAuthorizationService, type ResourceType } from "./modules
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
+import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
 import { createAdminRoutes } from "./routes/admin.js";
 import { createAuthRoutes } from "./routes/auth.js";
@@ -268,6 +269,8 @@ const auditLogService = createAuditLogService({
   auditLogRepo
 });
 
+const excelImportValidationService = createExcelImportValidationService();
+
 const certificateFileRepo = {
   async createCertificateFile({
     fileId,
@@ -327,6 +330,7 @@ app.route(
     authorizationGrantService,
     activityService,
     auditLogService,
+    excelImportValidationService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/modules/import/excel-validation.ts
+++ b/src/modules/import/excel-validation.ts
@@ -1,0 +1,226 @@
+import path from "node:path";
+import * as XLSX from "xlsx";
+
+export type ImportDatasetType = "enrollment" | "employment";
+
+export interface UploadedExcelFile {
+  name: string;
+  type: string;
+  size: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface ExcelImportValidationError {
+  row: number;
+  field: string;
+  reason: "missing required field" | "duplicate studentNo" | "invalid value";
+}
+
+export interface ExcelImportValidationResult {
+  total: number;
+  success: number;
+  failed: number;
+  errors: ExcelImportValidationError[];
+}
+
+export interface ValidateExcelImportInput {
+  datasetType: ImportDatasetType;
+  file?: UploadedExcelFile | null;
+}
+
+export interface ExcelImportValidationService {
+  validateExcelImport(input: ValidateExcelImportInput): Promise<ExcelImportValidationResult>;
+}
+
+export class MissingImportFileError extends Error {
+  constructor() {
+    super("file is required");
+    this.name = "MissingImportFileError";
+  }
+}
+
+export class UnsupportedExcelFileTypeError extends Error {
+  constructor() {
+    super("unsupported file type");
+    this.name = "UnsupportedExcelFileTypeError";
+  }
+}
+
+const EMPLOYMENT_STATUS_SET = new Set(["employed", "unemployed", "further_study", "civil_service"]);
+
+const REQUIRED_FIELDS: Record<ImportDatasetType, Array<string>> = {
+  enrollment: ["studentNo", "name", "score", "admissionYear"],
+  employment: ["studentNo", "name", "status", "salary"]
+};
+
+const isBlank = (value: unknown): boolean => {
+  if (value === null || value === undefined) {
+    return true;
+  }
+
+  if (typeof value === "string") {
+    return value.trim().length === 0;
+  }
+
+  return false;
+};
+
+const resolveString = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  return String(value).trim();
+};
+
+const resolveNumber = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  const text = resolveString(value);
+  if (!text) {
+    return null;
+  }
+
+  const parsed = Number(text);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const ensureXlsxFile = (file: UploadedExcelFile | null | undefined): UploadedExcelFile => {
+  if (!file) {
+    throw new MissingImportFileError();
+  }
+
+  const extension = path.extname(file.name).toLowerCase();
+  if (extension !== ".xlsx") {
+    throw new UnsupportedExcelFileTypeError();
+  }
+
+  return file;
+};
+
+const parseSheetRows = async (file: UploadedExcelFile): Promise<Array<Record<string, unknown>>> => {
+  const arrayBuffer = await file.arrayBuffer();
+  const workbook = XLSX.read(Buffer.from(arrayBuffer), { type: "buffer" });
+  const firstSheetName = workbook.SheetNames[0];
+
+  if (!firstSheetName) {
+    return [];
+  }
+
+  const sheet = workbook.Sheets[firstSheetName];
+
+  return XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+    defval: ""
+  });
+};
+
+const validateRows = (
+  datasetType: ImportDatasetType,
+  rows: Array<Record<string, unknown>>
+): ExcelImportValidationResult => {
+  const errors: ExcelImportValidationError[] = [];
+  const seenStudentNo = new Set<string>();
+  const failedRows = new Set<number>();
+
+  const requiredFields = REQUIRED_FIELDS[datasetType];
+
+  rows.forEach((row, index) => {
+    const rowNumber = index + 2;
+
+    for (const field of requiredFields) {
+      if (isBlank(row[field])) {
+        errors.push({
+          row: rowNumber,
+          field,
+          reason: "missing required field"
+        });
+        failedRows.add(rowNumber);
+      }
+    }
+
+    const studentNo = resolveString(row.studentNo);
+    if (studentNo) {
+      if (seenStudentNo.has(studentNo)) {
+        errors.push({
+          row: rowNumber,
+          field: "studentNo",
+          reason: "duplicate studentNo"
+        });
+        failedRows.add(rowNumber);
+      } else {
+        seenStudentNo.add(studentNo);
+      }
+    }
+
+    if (datasetType === "enrollment") {
+      const score = resolveNumber(row.score);
+      if (score === null || score < 0 || score > 750) {
+        errors.push({
+          row: rowNumber,
+          field: "score",
+          reason: "invalid value"
+        });
+        failedRows.add(rowNumber);
+      }
+
+      const admissionYear = resolveNumber(row.admissionYear);
+      if (
+        admissionYear === null ||
+        !Number.isInteger(admissionYear) ||
+        admissionYear < 2000 ||
+        admissionYear > 2100
+      ) {
+        errors.push({
+          row: rowNumber,
+          field: "admissionYear",
+          reason: "invalid value"
+        });
+        failedRows.add(rowNumber);
+      }
+    }
+
+    if (datasetType === "employment") {
+      const status = resolveString(row.status);
+      if (!EMPLOYMENT_STATUS_SET.has(status)) {
+        errors.push({
+          row: rowNumber,
+          field: "status",
+          reason: "invalid value"
+        });
+        failedRows.add(rowNumber);
+      }
+
+      const salary = resolveNumber(row.salary);
+      if (salary === null || salary < 0) {
+        errors.push({
+          row: rowNumber,
+          field: "salary",
+          reason: "invalid value"
+        });
+        failedRows.add(rowNumber);
+      }
+    }
+  });
+
+  const total = rows.length;
+  const failed = failedRows.size;
+
+  return {
+    total,
+    success: total - failed,
+    failed,
+    errors
+  };
+};
+
+export const createExcelImportValidationService = (): ExcelImportValidationService => {
+  return {
+    async validateExcelImport({ datasetType, file }: ValidateExcelImportInput): Promise<ExcelImportValidationResult> {
+      const validatedFile = ensureXlsxFile(file);
+      const rows = await parseSheetRows(validatedFile);
+      return validateRows(datasetType, rows);
+    }
+  };
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,6 +3,13 @@ import type { ActivityService, ActivityType } from "../modules/activity/service.
 import type { AuditLogService } from "../modules/audit/service.js";
 import type { AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
 import {
+  MissingImportFileError,
+  UnsupportedExcelFileTypeError,
+  type ExcelImportValidationService,
+  type ImportDatasetType,
+  type UploadedExcelFile
+} from "../modules/import/excel-validation.js";
+import {
   InvalidNewPasswordError,
   StudentNotFoundError,
   type StudentAuthService
@@ -31,6 +38,7 @@ export interface AdminRouteDependencies {
     AuditLogService,
     "logAuthorizationGrant" | "logAuthorizationRevoke" | "logPasswordReset" | "logActivityPublish"
   >;
+  excelImportValidationService?: Pick<ExcelImportValidationService, "validateExcelImport">;
   adminApiKey: string;
 }
 
@@ -101,6 +109,48 @@ const isForbiddenByAdminKey = (requestAdminKey: string | undefined, adminApiKey:
   return !requestAdminKey || requestAdminKey !== adminApiKey;
 };
 
+const isImportDatasetType = (datasetType: unknown): datasetType is ImportDatasetType => {
+  return datasetType === "enrollment" || datasetType === "employment";
+};
+
+const resolveDatasetType = (rawDatasetType: unknown): ImportDatasetType | null => {
+  if (typeof rawDatasetType !== "string") {
+    return null;
+  }
+
+  const datasetType = rawDatasetType.trim();
+  return isImportDatasetType(datasetType) ? datasetType : null;
+};
+
+const isUploadedExcelFile = (value: unknown): value is UploadedExcelFile => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as {
+    name?: unknown;
+    type?: unknown;
+    size?: unknown;
+    arrayBuffer?: unknown;
+  };
+
+  return (
+    typeof candidate.name === "string" &&
+    typeof candidate.type === "string" &&
+    typeof candidate.size === "number" &&
+    typeof candidate.arrayBuffer === "function"
+  );
+};
+
+const resolveImportFile = (body: Record<string, unknown>): UploadedExcelFile | null => {
+  const fileField = body.file;
+  if (Array.isArray(fileField)) {
+    return null;
+  }
+
+  return isUploadedExcelFile(fileField) ? fileField : null;
+};
+
 const resolveOperator = (rawOperator: string | undefined): string => {
   if (!rawOperator) {
     return "system-admin";
@@ -110,11 +160,18 @@ const resolveOperator = (rawOperator: string | undefined): string => {
   return operator.length > 0 ? operator : "system-admin";
 };
 
+const defaultExcelImportValidationService: Pick<ExcelImportValidationService, "validateExcelImport"> = {
+  async validateExcelImport() {
+    throw new Error("excelImportValidationService is not configured");
+  }
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
   authorizationGrantService,
   activityService,
   auditLogService,
+  excelImportValidationService = defaultExcelImportValidationService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
@@ -270,6 +327,46 @@ export const createAdminRoutes = ({
     });
 
     return c.json({ message: "activity published" }, 201);
+  });
+
+  admin.post("/imports/excel/validate", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.parseBody({ all: true });
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const datasetType = resolveDatasetType(body.datasetType);
+    if (!datasetType) {
+      return c.json({ message: "datasetType must be enrollment or employment" }, 400);
+    }
+
+    const file = resolveImportFile(body);
+
+    try {
+      const result = await excelImportValidationService.validateExcelImport({
+        datasetType,
+        file
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof MissingImportFileError) {
+        return c.json({ message: "file is required" }, 400);
+      }
+
+      if (error instanceof UnsupportedExcelFileTypeError) {
+        return c.json({ message: "unsupported file type" }, 415);
+      }
+
+      throw error;
+    }
   });
 
   return admin;

--- a/tests/import/admin-excel-import.test.ts
+++ b/tests/import/admin-excel-import.test.ts
@@ -1,0 +1,216 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { File } from "node:buffer";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+import {
+  MissingImportFileError,
+  UnsupportedExcelFileTypeError,
+  type ExcelImportValidationService
+} from "../../src/modules/import/excel-validation.ts";
+
+const adminApiKey = "admin-secret-key";
+
+interface Fixture {
+  calls: Array<{ datasetType: "enrollment" | "employment" }>;
+}
+
+const createNoopAdminApp = (
+  fixture: Fixture,
+  excelImportValidationService: Pick<ExcelImportValidationService, "validateExcelImport">
+) => {
+  const app = new Hono();
+
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      authorizationGrantService: {
+        async assignGrant() {
+          return;
+        },
+        async revokeGrant() {
+          return;
+        }
+      },
+      activityService: {
+        async publishActivity() {
+          return;
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          return;
+        },
+        async logAuthorizationRevoke() {
+          return;
+        },
+        async logPasswordReset() {
+          return;
+        },
+        async logActivityPublish() {
+          return;
+        }
+      },
+      excelImportValidationService,
+      adminApiKey
+    })
+  );
+
+  return app;
+};
+
+test("admin excel import validate should return 403 when admin key is missing", async () => {
+  const fixture: Fixture = { calls: [] };
+
+  const app = createNoopAdminApp(fixture, {
+    async validateExcelImport() {
+      fixture.calls.push({ datasetType: "enrollment" });
+      return { total: 0, success: 0, failed: 0, errors: [] };
+    }
+  });
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new File([Buffer.from("dummy")], "demo.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    })
+  );
+  formData.append("datasetType", "enrollment");
+
+  const response = await app.request("/admin/imports/excel/validate", {
+    method: "POST",
+    body: formData
+  });
+
+  assert.equal(response.status, 403);
+  assert.equal(fixture.calls.length, 0);
+});
+
+test("admin excel import validate should return 400 when datasetType is invalid", async () => {
+  const fixture: Fixture = { calls: [] };
+
+  const app = createNoopAdminApp(fixture, {
+    async validateExcelImport() {
+      fixture.calls.push({ datasetType: "enrollment" });
+      return { total: 0, success: 0, failed: 0, errors: [] };
+    }
+  });
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new File([Buffer.from("dummy")], "demo.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    })
+  );
+  formData.append("datasetType", "unknown");
+
+  const response = await app.request("/admin/imports/excel/validate", {
+    method: "POST",
+    headers: {
+      "X-Admin-Key": adminApiKey
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 400);
+  assert.equal(fixture.calls.length, 0);
+});
+
+test("admin excel import validate should return 415 when file type is unsupported", async () => {
+  const fixture: Fixture = { calls: [] };
+
+  const app = createNoopAdminApp(fixture, {
+    async validateExcelImport() {
+      throw new UnsupportedExcelFileTypeError();
+    }
+  });
+
+  const formData = new FormData();
+  formData.append("file", new File([Buffer.from("dummy")], "demo.csv", { type: "text/csv" }));
+  formData.append("datasetType", "employment");
+
+  const response = await app.request("/admin/imports/excel/validate", {
+    method: "POST",
+    headers: {
+      "X-Admin-Key": adminApiKey
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 415);
+  assert.equal(fixture.calls.length, 0);
+});
+
+test("admin excel import validate should return validation summary", async () => {
+  const fixture: Fixture = { calls: [] };
+
+  const app = createNoopAdminApp(fixture, {
+    async validateExcelImport(input) {
+      fixture.calls.push({ datasetType: input.datasetType });
+      return {
+        total: 10,
+        success: 7,
+        failed: 3,
+        errors: [{ row: 3, field: "studentNo", reason: "duplicate studentNo" }]
+      };
+    }
+  });
+
+  const formData = new FormData();
+  formData.append(
+    "file",
+    new File([Buffer.from("dummy")], "demo.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    })
+  );
+  formData.append("datasetType", "employment");
+
+  const response = await app.request("/admin/imports/excel/validate", {
+    method: "POST",
+    headers: {
+      "X-Admin-Key": adminApiKey
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    total: 10,
+    success: 7,
+    failed: 3,
+    errors: [{ row: 3, field: "studentNo", reason: "duplicate studentNo" }]
+  });
+
+  assert.equal(fixture.calls.length, 1);
+  assert.equal(fixture.calls[0].datasetType, "employment");
+});
+
+test("admin excel import validate should return 400 when file is missing", async () => {
+  const fixture: Fixture = { calls: [] };
+
+  const app = createNoopAdminApp(fixture, {
+    async validateExcelImport() {
+      throw new MissingImportFileError();
+    }
+  });
+
+  const formData = new FormData();
+  formData.append("datasetType", "enrollment");
+
+  const response = await app.request("/admin/imports/excel/validate", {
+    method: "POST",
+    headers: {
+      "X-Admin-Key": adminApiKey
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 400);
+});

--- a/tests/import/excel-validation.test.ts
+++ b/tests/import/excel-validation.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { File } from "node:buffer";
+import * as XLSX from "xlsx";
+import { createExcelImportValidationService } from "../../src/modules/import/excel-validation.ts";
+
+const createXlsxFile = (rows: Array<Record<string, unknown>>, fileName = "dataset.xlsx") => {
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, "Sheet1");
+  const buffer = XLSX.write(workbook, { type: "buffer", bookType: "xlsx" }) as Buffer;
+
+  return new File([buffer], fileName, {
+    type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  });
+};
+
+test("excel validation should detect missing fields, duplicate studentNo and illegal values for enrollment", async () => {
+  const service = createExcelImportValidationService();
+
+  const file = createXlsxFile([
+    { studentNo: "S001", name: "Alice", score: 620, admissionYear: 2024 },
+    { studentNo: "S002", name: "", score: 600, admissionYear: 2024 },
+    { studentNo: "S001", name: "Repeat", score: 610, admissionYear: 2024 },
+    { studentNo: "S004", name: "BadScore", score: 900, admissionYear: 2024 },
+    { studentNo: "S005", name: "BadYear", score: 580, admissionYear: 1900 }
+  ]);
+
+  const result = await service.validateExcelImport({
+    datasetType: "enrollment",
+    file
+  });
+
+  assert.equal(result.total, 5);
+  assert.equal(result.success, 1);
+  assert.equal(result.failed, 4);
+  assert.ok(result.errors.some((error) => error.field === "name" && error.reason === "missing required field"));
+  assert.ok(result.errors.some((error) => error.field === "studentNo" && error.reason === "duplicate studentNo"));
+  assert.ok(result.errors.some((error) => error.field === "score" && error.reason === "invalid value"));
+  assert.ok(result.errors.some((error) => error.field === "admissionYear" && error.reason === "invalid value"));
+});
+
+test("excel validation should detect illegal employment status", async () => {
+  const service = createExcelImportValidationService();
+
+  const file = createXlsxFile([
+    { studentNo: "E001", name: "Bob", status: "employed", salary: 6000 },
+    { studentNo: "E002", name: "Tom", status: "unknown", salary: 4000 }
+  ]);
+
+  const result = await service.validateExcelImport({
+    datasetType: "employment",
+    file
+  });
+
+  assert.equal(result.total, 2);
+  assert.equal(result.success, 1);
+  assert.equal(result.failed, 1);
+  assert.ok(result.errors.some((error) => error.field === "status" && error.reason === "invalid value"));
+});


### PR DESCRIPTION
## 背景
实现 B06：Excel 导入与质量校验基础能力（招生/就业）。

## 变更内容
- 新增导入校验服务：`src/modules/import/excel-validation.ts`
  - 仅支持 `.xlsx`
  - `datasetType`：`enrollment` / `employment`
  - 校验项：缺失字段、重复学号、非法值
  - 返回：`total/success/failed/errors[]`
- 扩展管理员接口：`POST /admin/imports/excel/validate`
  - admin key 鉴权
  - multipart 参数：`datasetType` + `file`
  - 错误语义：
    - 403：无权限
    - 400：参数错误/缺文件
    - 415：文件类型不支持
- 新增测试：
  - `tests/import/excel-validation.test.ts`
  - `tests/import/admin-excel-import.test.ts`
- 新增依赖：`xlsx`

## 验证
- [x] `npm test`（50 passed）
- [x] `npm run check`
- [x] `npm run build`

Closes #8
