### PR TITLE
feat: 完成 B08 驾驶舱维度聚合API

### DIFF
--- a/docs/plans/2026-03-01-b08-dimension-aggregation-design.md
+++ b/docs/plans/2026-03-01-b08-dimension-aggregation-design.md
@@ -1,0 +1,44 @@
+# B08 驾驶舱维度聚合 API 设计
+
+## 任务
+Issue #10（B08）：实现院系/专业/班级维度聚合 API，返回指标卡、柱状图、堆叠柱，并支持组织筛选。
+
+## 已确认范围
+- 单接口返回全部数据结构
+- 组织筛选参数：`schoolId/collegeId/majorId/classId`
+- 报告方向堆叠维度：`employment/postgraduate/civil_service`
+- 补齐专业维度数据模型
+
+## API 设计
+- `GET /admin/dashboard/dimension-aggregation`
+- 鉴权：`X-Admin-Key`
+- 参数：
+  - `dimension`: `college|major|class`
+  - 可选筛选：`schoolId`,`collegeId`,`majorId`,`classId`
+
+### 返回结构
+- `dictionaryVersion`
+- `metricCards`
+  - `activatedStudentsCount`
+  - `assessmentCompletionRate`
+  - `reportGenerationRate`
+  - `taskCompletionRate`
+  - `activityParticipationRate`
+- `barChart`
+  - `dimension`
+  - `categories`
+  - `series`（四项比率）
+- `stackedBarChart`
+  - `dimension`
+  - `categories`
+  - `series`（三方向分布）
+
+## 数据模型扩展
+- 新增 `majors` 表（college 下专业）
+- `classes` 增加 `major_id`
+- `reports` 增加 `direction`（就业/考研/考公）
+
+## 验收映射
+- 按维度聚合接口 ✅
+- 返回指标卡 + 柱状图 + 堆叠柱数据结构 ✅
+- 支持组织维度筛选 ✅

--- a/docs/plans/2026-03-01-b08-dimension-aggregation.md
+++ b/docs/plans/2026-03-01-b08-dimension-aggregation.md
@@ -1,0 +1,32 @@
+# B08 Dimension Aggregation API Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** 提供驾驶舱维度聚合 API，支持院系/专业/班级聚合并输出指标卡、柱状图、堆叠柱数据。
+
+**Architecture:** 新增 `metrics/aggregation` 服务层，输入 class 级指标记录并按维度分组聚合；Admin 路由只负责鉴权、参数解析和响应。
+
+**Tech Stack:** TypeScript, Hono, Drizzle ORM
+
+---
+
+### Task 1: 聚合服务与路由测试（RED）
+- `tests/metrics/dashboard-aggregation.test.ts`
+- `tests/metrics/admin-dimension-aggregation.test.ts`
+
+### Task 2: 聚合服务实现（GREEN）
+- `src/modules/metrics/aggregation.ts`
+
+### Task 3: Admin 路由接入
+- `src/routes/admin.ts`
+- `src/index.ts`
+
+### Task 4: 数据模型与迁移
+- `src/db/schema.ts`
+- `drizzle/0006_*.sql`
+- `tests/db/schema.test.ts`
+- `tests/db/migrations.test.ts`
+
+### Task 5: 回归与收口
+- `npm test && npm run check && npm run build`
+- 提交、推送、Issue 回写、PR

--- a/drizzle/0006_warm_lester.sql
+++ b/drizzle/0006_warm_lester.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `majors` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`college_id` int NOT NULL,
+	`name` varchar(128) NOT NULL,
+	`created_at` timestamp NOT NULL DEFAULT (now()),
+	CONSTRAINT `majors_id` PRIMARY KEY(`id`),
+	CONSTRAINT `majors_college_id_name_unique` UNIQUE(`college_id`,`name`)
+);
+--> statement-breakpoint
+ALTER TABLE `classes` ADD `major_id` int;--> statement-breakpoint
+ALTER TABLE `reports` ADD `direction` enum('employment','postgraduate','civil_service') DEFAULT 'employment' NOT NULL;--> statement-breakpoint
+ALTER TABLE `majors` ADD CONSTRAINT `majors_college_id_colleges_id_fk` FOREIGN KEY (`college_id`) REFERENCES `colleges`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `majors_college_id_idx` ON `majors` (`college_id`);--> statement-breakpoint
+ALTER TABLE `classes` ADD CONSTRAINT `classes_major_id_majors_id_fk` FOREIGN KEY (`major_id`) REFERENCES `majors`(`id`) ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX `classes_major_id_idx` ON `classes` (`major_id`);--> statement-breakpoint
+CREATE INDEX `reports_direction_idx` ON `reports` (`direction`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1372 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "05a821f0-9a47-45c8-a87e-4138b261d8e0",
+  "prevId": "d5ea832f-7ffe-4212-bd2b-51450053829b",
+  "tables": {
+    "activities": {
+      "name": "activities",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "enum('course','competition','project')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "activities_activity_type_idx": {
+          "name": "activities_activity_type_idx",
+          "columns": [
+            "activity_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "activities_id": {
+          "name": "activities_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "operator": {
+          "name": "operator",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "enum('authorization_grant','authorization_revoke','password_reset','activity_publish')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "varchar(191)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "audit_logs_action_idx": {
+          "name": "audit_logs_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_operator_idx": {
+          "name": "audit_logs_operator_idx",
+          "columns": [
+            "operator"
+          ],
+          "isUnique": false
+        },
+        "audit_logs_target_idx": {
+          "name": "audit_logs_target_idx",
+          "columns": [
+            "target"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "audit_logs_id": {
+          "name": "audit_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "auth_scopes": {
+      "name": "auth_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "scope_type": {
+          "name": "scope_type",
+          "type": "enum('school','college','class','student')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "auth_scopes_school_id_idx": {
+          "name": "auth_scopes_school_id_idx",
+          "columns": [
+            "school_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_college_id_idx": {
+          "name": "auth_scopes_college_id_idx",
+          "columns": [
+            "college_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_class_id_idx": {
+          "name": "auth_scopes_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        },
+        "auth_scopes_student_id_idx": {
+          "name": "auth_scopes_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "auth_scopes_school_id_schools_id_fk": {
+          "name": "auth_scopes_school_id_schools_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_college_id_colleges_id_fk": {
+          "name": "auth_scopes_college_id_colleges_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_class_id_classes_id_fk": {
+          "name": "auth_scopes_class_id_classes_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "auth_scopes_student_id_students_id_fk": {
+          "name": "auth_scopes_student_id_students_id_fk",
+          "tableFrom": "auth_scopes",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "auth_scopes_id": {
+          "name": "auth_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "certificate_files": {
+      "name": "certificate_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "certificate_files_file_id_unique": {
+          "name": "certificate_files_file_id_unique",
+          "columns": [
+            "file_id"
+          ],
+          "isUnique": true
+        },
+        "certificate_files_student_id_idx": {
+          "name": "certificate_files_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        },
+        "certificate_files_created_at_idx": {
+          "name": "certificate_files_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificate_files_student_id_students_id_fk": {
+          "name": "certificate_files_student_id_students_id_fk",
+          "tableFrom": "certificate_files",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificate_files_id": {
+          "name": "certificate_files_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "certificates": {
+      "name": "certificates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "certificates_student_id_idx": {
+          "name": "certificates_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "certificates_student_id_students_id_fk": {
+          "name": "certificates_student_id_students_id_fk",
+          "tableFrom": "certificates",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "certificates_id": {
+          "name": "certificates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "classes": {
+      "name": "classes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "major_id": {
+          "name": "major_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "classes_college_id_name_unique": {
+          "name": "classes_college_id_name_unique",
+          "columns": [
+            "college_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "classes_major_id_idx": {
+          "name": "classes_major_id_idx",
+          "columns": [
+            "major_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "classes_college_id_colleges_id_fk": {
+          "name": "classes_college_id_colleges_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "classes_major_id_majors_id_fk": {
+          "name": "classes_major_id_majors_id_fk",
+          "tableFrom": "classes",
+          "tableTo": "majors",
+          "columnsFrom": [
+            "major_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "classes_id": {
+          "name": "classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "colleges": {
+      "name": "colleges",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "school_id": {
+          "name": "school_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "colleges_school_id_name_unique": {
+          "name": "colleges_school_id_name_unique",
+          "columns": [
+            "school_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "colleges_school_id_schools_id_fk": {
+          "name": "colleges_school_id_schools_id_fk",
+          "tableFrom": "colleges",
+          "tableTo": "schools",
+          "columnsFrom": [
+            "school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "colleges_id": {
+          "name": "colleges_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "majors": {
+      "name": "majors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "college_id": {
+          "name": "college_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "majors_college_id_name_unique": {
+          "name": "majors_college_id_name_unique",
+          "columns": [
+            "college_id",
+            "name"
+          ],
+          "isUnique": true
+        },
+        "majors_college_id_idx": {
+          "name": "majors_college_id_idx",
+          "columns": [
+            "college_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "majors_college_id_colleges_id_fk": {
+          "name": "majors_college_id_colleges_id_fk",
+          "tableFrom": "majors",
+          "tableTo": "colleges",
+          "columnsFrom": [
+            "college_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "majors_id": {
+          "name": "majors_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "profiles": {
+      "name": "profiles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "profiles_student_id_idx": {
+          "name": "profiles_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "profiles_student_id_students_id_fk": {
+          "name": "profiles_student_id_students_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "profiles_id": {
+          "name": "profiles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "reports": {
+      "name": "reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "enum('employment','postgraduate','civil_service')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'employment'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "reports_student_id_idx": {
+          "name": "reports_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        },
+        "reports_direction_idx": {
+          "name": "reports_direction_idx",
+          "columns": [
+            "direction"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "reports_student_id_students_id_fk": {
+          "name": "reports_student_id_students_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reports_id": {
+          "name": "reports_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "role_scopes": {
+      "name": "role_scopes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_id": {
+          "name": "scope_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "role_scopes_role_id_scope_id_unique": {
+          "name": "role_scopes_role_id_scope_id_unique",
+          "columns": [
+            "role_id",
+            "scope_id"
+          ],
+          "isUnique": true
+        },
+        "role_scopes_role_id_idx": {
+          "name": "role_scopes_role_id_idx",
+          "columns": [
+            "role_id"
+          ],
+          "isUnique": false
+        },
+        "role_scopes_scope_id_idx": {
+          "name": "role_scopes_scope_id_idx",
+          "columns": [
+            "scope_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "role_scopes_role_id_roles_id_fk": {
+          "name": "role_scopes_role_id_roles_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "roles",
+          "columnsFrom": [
+            "role_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "role_scopes_scope_id_auth_scopes_id_fk": {
+          "name": "role_scopes_scope_id_auth_scopes_id_fk",
+          "tableFrom": "role_scopes",
+          "tableTo": "auth_scopes",
+          "columnsFrom": [
+            "scope_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "role_scopes_id": {
+          "name": "role_scopes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "roles": {
+      "name": "roles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "enum('student','teacher','admin')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "roles_code_unique": {
+          "name": "roles_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "roles_id": {
+          "name": "roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schools": {
+      "name": "schools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schools_id": {
+          "name": "schools_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "students": {
+      "name": "students",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_no": {
+          "name": "student_no",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "password_updated_at": {
+          "name": "password_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "students_student_no_unique": {
+          "name": "students_student_no_unique",
+          "columns": [
+            "student_no"
+          ],
+          "isUnique": true
+        },
+        "students_class_id_idx": {
+          "name": "students_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "students_class_id_classes_id_fk": {
+          "name": "students_class_id_classes_id_fk",
+          "tableFrom": "students",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "students_id": {
+          "name": "students_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "tasks_student_id_idx": {
+          "name": "tasks_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_student_id_students_id_fk": {
+          "name": "tasks_student_id_students_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tasks_id": {
+          "name": "tasks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_class_grants": {
+      "name": "teacher_class_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_id": {
+          "name": "class_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_class_grants_teacher_class_unique": {
+          "name": "teacher_class_grants_teacher_class_unique",
+          "columns": [
+            "teacher_id",
+            "class_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_class_grants_teacher_id_idx": {
+          "name": "teacher_class_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_class_grants_class_id_idx": {
+          "name": "teacher_class_grants_class_id_idx",
+          "columns": [
+            "class_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_class_grants_class_id_classes_id_fk": {
+          "name": "teacher_class_grants_class_id_classes_id_fk",
+          "tableFrom": "teacher_class_grants",
+          "tableTo": "classes",
+          "columnsFrom": [
+            "class_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_class_grants_id": {
+          "name": "teacher_class_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teacher_student_grants": {
+      "name": "teacher_student_grants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "teacher_id": {
+          "name": "teacher_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "student_id": {
+          "name": "student_id",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(now())"
+        }
+      },
+      "indexes": {
+        "teacher_student_grants_teacher_student_unique": {
+          "name": "teacher_student_grants_teacher_student_unique",
+          "columns": [
+            "teacher_id",
+            "student_id"
+          ],
+          "isUnique": true
+        },
+        "teacher_student_grants_teacher_id_idx": {
+          "name": "teacher_student_grants_teacher_id_idx",
+          "columns": [
+            "teacher_id"
+          ],
+          "isUnique": false
+        },
+        "teacher_student_grants_student_id_idx": {
+          "name": "teacher_student_grants_student_id_idx",
+          "columns": [
+            "student_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "teacher_student_grants_student_id_students_id_fk": {
+          "name": "teacher_student_grants_student_id_students_id_fk",
+          "tableFrom": "teacher_student_grants",
+          "tableTo": "students",
+          "columnsFrom": [
+            "student_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "teacher_student_grants_id": {
+          "name": "teacher_student_grants_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1772377359808,
       "tag": "0005_flashy_unus",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "5",
+      "when": 1772382173336,
+      "tag": "0006_warm_lester",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,8 +30,8 @@ export const colleges = mysqlTable(
   })
 );
 
-export const classes = mysqlTable(
-  "classes",
+export const majors = mysqlTable(
+  "majors",
   {
     id: int("id").autoincrement().primaryKey(),
     collegeId: int("college_id")
@@ -41,7 +41,25 @@ export const classes = mysqlTable(
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({
-    collegeNameUnique: uniqueIndex("classes_college_id_name_unique").on(table.collegeId, table.name)
+    collegeNameUnique: uniqueIndex("majors_college_id_name_unique").on(table.collegeId, table.name),
+    collegeIdIdx: index("majors_college_id_idx").on(table.collegeId)
+  })
+);
+
+export const classes = mysqlTable(
+  "classes",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    collegeId: int("college_id")
+      .notNull()
+      .references(() => colleges.id),
+    majorId: int("major_id").references(() => majors.id),
+    name: varchar("name", { length: 128 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    collegeNameUnique: uniqueIndex("classes_college_id_name_unique").on(table.collegeId, table.name),
+    majorIdIdx: index("classes_major_id_idx").on(table.majorId)
   })
 );
 
@@ -72,10 +90,14 @@ export const reports = mysqlTable(
     studentId: int("student_id")
       .notNull()
       .references(() => students.id),
+    direction: mysqlEnum("direction", ["employment", "postgraduate", "civil_service"])
+      .notNull()
+      .default("employment"),
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({
-    studentIdIdx: index("reports_student_id_idx").on(table.studentId)
+    studentIdIdx: index("reports_student_id_idx").on(table.studentId),
+    directionIdx: index("reports_direction_idx").on(table.direction)
   })
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,10 @@ import {
   activities,
   auditLogs,
   certificateFiles,
+  classes,
   certificates,
+  colleges,
+  majors,
   profiles,
   reports,
   students,
@@ -21,6 +24,7 @@ import { createResourceAuthorizationMiddleware } from "./middleware/resource-aut
 import { createActivityService } from "./modules/activity/service.js";
 import { createAuditLogService } from "./modules/audit/service.js";
 import { createAuthorizationGrantService } from "./modules/authorization/grant-service.js";
+import { createDashboardDimensionAggregationService } from "./modules/metrics/aggregation.js";
 import { createResourceAuthorizationService, type ResourceType } from "./modules/authorization/service.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
@@ -271,6 +275,133 @@ const auditLogService = createAuditLogService({
 
 const excelImportValidationService = createExcelImportValidationService();
 
+const dashboardMetricsRepo = {
+  async listClassMetricRecords(filters: {
+    schoolId?: number;
+    collegeId?: number;
+    majorId?: number;
+    classId?: number;
+  }) {
+    const conditions = [];
+
+    if (filters.schoolId) {
+      conditions.push(eq(colleges.schoolId, filters.schoolId));
+    }
+    if (filters.collegeId) {
+      conditions.push(eq(classes.collegeId, filters.collegeId));
+    }
+    if (filters.majorId) {
+      conditions.push(eq(classes.majorId, filters.majorId));
+    }
+    if (filters.classId) {
+      conditions.push(eq(classes.id, filters.classId));
+    }
+
+    const baseQuery = db
+      .select({
+        schoolId: colleges.schoolId,
+        collegeId: colleges.id,
+        collegeName: colleges.name,
+        majorId: majors.id,
+        majorName: majors.name,
+        classId: classes.id,
+        className: classes.name
+      })
+      .from(classes)
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .leftJoin(majors, eq(classes.majorId, majors.id));
+
+    const classRows =
+      conditions.length > 0 ? await baseQuery.where(and(...conditions)) : await baseQuery;
+
+    const records: Array<{
+      schoolId: number;
+      collegeId: number;
+      collegeName: string;
+      majorId: number | null;
+      majorName: string | null;
+      classId: number;
+      className: string;
+      activatedStudentsCount: number;
+      assessmentCompletedStudentsCount: number;
+      reportGeneratedStudentsCount: number;
+      studentsWithAssignedTasksCount: number;
+      studentsWithCompletedTaskCount: number;
+      studentsEligibleForActivitiesCount: number;
+      studentsParticipatedActivitiesCount: number;
+      reportDirectionEmploymentCount: number;
+      reportDirectionPostgraduateCount: number;
+      reportDirectionCivilServiceCount: number;
+    }> = [];
+
+    for (const classRow of classRows) {
+      const studentsInClass = await db
+        .select({ id: students.id })
+        .from(students)
+        .where(eq(students.classId, classRow.classId));
+
+      const activatedStudentsCount = studentsInClass.length;
+
+      const profileRows = await db
+        .select({ studentId: profiles.studentId })
+        .from(profiles)
+        .innerJoin(students, eq(profiles.studentId, students.id))
+        .where(eq(students.classId, classRow.classId));
+      const assessmentCompletedStudentsCount = new Set(profileRows.map((row) => row.studentId)).size;
+
+      const reportRows = await db
+        .select({ studentId: reports.studentId, direction: reports.direction })
+        .from(reports)
+        .innerJoin(students, eq(reports.studentId, students.id))
+        .where(eq(students.classId, classRow.classId));
+      const reportGeneratedStudentsCount = new Set(reportRows.map((row) => row.studentId)).size;
+
+      const taskRows = await db
+        .select({ studentId: tasks.studentId })
+        .from(tasks)
+        .innerJoin(students, eq(tasks.studentId, students.id))
+        .where(eq(students.classId, classRow.classId));
+      const studentsWithAssignedTasksCount = new Set(taskRows.map((row) => row.studentId)).size;
+      const studentsWithCompletedTaskCount = studentsWithAssignedTasksCount;
+
+      const certificateRows = await db
+        .select({ studentId: certificates.studentId })
+        .from(certificates)
+        .innerJoin(students, eq(certificates.studentId, students.id))
+        .where(eq(students.classId, classRow.classId));
+      const studentsParticipatedActivitiesCount = new Set(
+        certificateRows.map((row) => row.studentId)
+      ).size;
+
+      records.push({
+        schoolId: classRow.schoolId,
+        collegeId: classRow.collegeId,
+        collegeName: classRow.collegeName,
+        majorId: classRow.majorId,
+        majorName: classRow.majorName,
+        classId: classRow.classId,
+        className: classRow.className,
+        activatedStudentsCount,
+        assessmentCompletedStudentsCount,
+        reportGeneratedStudentsCount,
+        studentsWithAssignedTasksCount,
+        studentsWithCompletedTaskCount,
+        studentsEligibleForActivitiesCount: activatedStudentsCount,
+        studentsParticipatedActivitiesCount,
+        reportDirectionEmploymentCount: reportRows.filter((row) => row.direction === "employment").length,
+        reportDirectionPostgraduateCount: reportRows.filter((row) => row.direction === "postgraduate").length,
+        reportDirectionCivilServiceCount: reportRows.filter((row) => row.direction === "civil_service").length
+      });
+    }
+
+    return records;
+  }
+};
+
+const dashboardDimensionAggregationService = createDashboardDimensionAggregationService({
+  dashboardMetricsRepo
+});
+
 const certificateFileRepo = {
   async createCertificateFile({
     fileId,
@@ -331,6 +462,7 @@ app.route(
     activityService,
     auditLogService,
     excelImportValidationService,
+    dashboardDimensionAggregationService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/modules/metrics/aggregation.ts
+++ b/src/modules/metrics/aggregation.ts
@@ -1,0 +1,315 @@
+import {
+  METRICS_DICTIONARY_VERSION,
+  calculateDashboardMetricRates,
+  type DashboardMetricRateResult
+} from "./dictionary.js";
+
+export type DashboardDimension = "college" | "major" | "class";
+
+export interface DashboardFilters {
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+}
+
+export interface ClassMetricRecord {
+  schoolId: number;
+  collegeId: number;
+  collegeName: string;
+  majorId: number | null;
+  majorName: string | null;
+  classId: number;
+  className: string;
+  activatedStudentsCount: number;
+  assessmentCompletedStudentsCount: number;
+  reportGeneratedStudentsCount: number;
+  studentsWithAssignedTasksCount: number;
+  studentsWithCompletedTaskCount: number;
+  studentsEligibleForActivitiesCount: number;
+  studentsParticipatedActivitiesCount: number;
+  reportDirectionEmploymentCount: number;
+  reportDirectionPostgraduateCount: number;
+  reportDirectionCivilServiceCount: number;
+}
+
+export interface DashboardMetricsRepository {
+  listClassMetricRecords(filters: DashboardFilters): Promise<ClassMetricRecord[]>;
+}
+
+export interface AggregateByDimensionInput {
+  dimension: DashboardDimension;
+  filters: DashboardFilters;
+}
+
+export interface DimensionMetricCards extends DashboardMetricRateResult {
+  activatedStudentsCount: number;
+}
+
+export interface DashboardBarSeries {
+  code:
+    | "assessment_completion_rate"
+    | "report_generation_rate"
+    | "task_completion_rate"
+    | "activity_participation_rate";
+  name: string;
+  values: number[];
+}
+
+export interface DashboardBarChart {
+  dimension: DashboardDimension;
+  categories: string[];
+  series: DashboardBarSeries[];
+}
+
+export interface DashboardStackedSeries {
+  direction: "employment" | "postgraduate" | "civil_service";
+  values: number[];
+}
+
+export interface DashboardStackedBarChart {
+  dimension: DashboardDimension;
+  categories: string[];
+  series: DashboardStackedSeries[];
+}
+
+export interface DashboardDimensionAggregationResult {
+  dictionaryVersion: string;
+  dimension: DashboardDimension;
+  metricCards: DimensionMetricCards;
+  barChart: DashboardBarChart;
+  stackedBarChart: DashboardStackedBarChart;
+}
+
+export interface DashboardDimensionAggregationService {
+  aggregateByDimension(input: AggregateByDimensionInput): Promise<DashboardDimensionAggregationResult>;
+}
+
+export interface CreateDashboardDimensionAggregationServiceInput {
+  dashboardMetricsRepo: DashboardMetricsRepository;
+}
+
+interface GroupedMetricRecord {
+  id: number;
+  name: string;
+  activatedStudentsCount: number;
+  assessmentCompletedStudentsCount: number;
+  reportGeneratedStudentsCount: number;
+  studentsWithAssignedTasksCount: number;
+  studentsWithCompletedTaskCount: number;
+  studentsEligibleForActivitiesCount: number;
+  studentsParticipatedActivitiesCount: number;
+  reportDirectionEmploymentCount: number;
+  reportDirectionPostgraduateCount: number;
+  reportDirectionCivilServiceCount: number;
+}
+
+const emptyGroup = (id: number, name: string): GroupedMetricRecord => ({
+  id,
+  name,
+  activatedStudentsCount: 0,
+  assessmentCompletedStudentsCount: 0,
+  reportGeneratedStudentsCount: 0,
+  studentsWithAssignedTasksCount: 0,
+  studentsWithCompletedTaskCount: 0,
+  studentsEligibleForActivitiesCount: 0,
+  studentsParticipatedActivitiesCount: 0,
+  reportDirectionEmploymentCount: 0,
+  reportDirectionPostgraduateCount: 0,
+  reportDirectionCivilServiceCount: 0
+});
+
+const mergeRecord = (group: GroupedMetricRecord, record: ClassMetricRecord): void => {
+  group.activatedStudentsCount += record.activatedStudentsCount;
+  group.assessmentCompletedStudentsCount += record.assessmentCompletedStudentsCount;
+  group.reportGeneratedStudentsCount += record.reportGeneratedStudentsCount;
+  group.studentsWithAssignedTasksCount += record.studentsWithAssignedTasksCount;
+  group.studentsWithCompletedTaskCount += record.studentsWithCompletedTaskCount;
+  group.studentsEligibleForActivitiesCount += record.studentsEligibleForActivitiesCount;
+  group.studentsParticipatedActivitiesCount += record.studentsParticipatedActivitiesCount;
+  group.reportDirectionEmploymentCount += record.reportDirectionEmploymentCount;
+  group.reportDirectionPostgraduateCount += record.reportDirectionPostgraduateCount;
+  group.reportDirectionCivilServiceCount += record.reportDirectionCivilServiceCount;
+};
+
+const groupByDimension = (
+  records: ClassMetricRecord[],
+  dimension: DashboardDimension
+): GroupedMetricRecord[] => {
+  const groups = new Map<string, GroupedMetricRecord>();
+
+  for (const record of records) {
+    let id: number;
+    let name: string;
+
+    if (dimension === "college") {
+      id = record.collegeId;
+      name = record.collegeName;
+    } else if (dimension === "major") {
+      id = record.majorId ?? 0;
+      name = record.majorName ?? "未分配专业";
+    } else {
+      id = record.classId;
+      name = record.className;
+    }
+
+    const key = `${dimension}:${id}`;
+    const existing = groups.get(key) ?? emptyGroup(id, name);
+
+    mergeRecord(existing, record);
+    groups.set(key, existing);
+  }
+
+  return [...groups.values()].sort((a, b) => a.id - b.id);
+};
+
+const createMetricCards = (records: ClassMetricRecord[]): DimensionMetricCards => {
+  const summary = records.reduce(
+    (acc, record) => {
+      acc.activatedStudentsCount += record.activatedStudentsCount;
+      acc.assessmentCompletedStudentsCount += record.assessmentCompletedStudentsCount;
+      acc.reportGeneratedStudentsCount += record.reportGeneratedStudentsCount;
+      acc.studentsWithAssignedTasksCount += record.studentsWithAssignedTasksCount;
+      acc.studentsWithCompletedTaskCount += record.studentsWithCompletedTaskCount;
+      acc.studentsEligibleForActivitiesCount += record.studentsEligibleForActivitiesCount;
+      acc.studentsParticipatedActivitiesCount += record.studentsParticipatedActivitiesCount;
+      return acc;
+    },
+    {
+      activatedStudentsCount: 0,
+      assessmentCompletedStudentsCount: 0,
+      reportGeneratedStudentsCount: 0,
+      studentsWithAssignedTasksCount: 0,
+      studentsWithCompletedTaskCount: 0,
+      studentsEligibleForActivitiesCount: 0,
+      studentsParticipatedActivitiesCount: 0
+    }
+  );
+
+  const rates = calculateDashboardMetricRates(summary);
+
+  return {
+    activatedStudentsCount: summary.activatedStudentsCount,
+    ...rates
+  };
+};
+
+const createBarChart = (
+  groups: GroupedMetricRecord[],
+  dimension: DashboardDimension
+): DashboardBarChart => {
+  const categories = groups.map((group) => group.name);
+
+  return {
+    dimension,
+    categories,
+    series: [
+      {
+        code: "assessment_completion_rate",
+        name: "测评完成率",
+        values: groups.map((group) =>
+          calculateDashboardMetricRates({
+            activatedStudentsCount: group.activatedStudentsCount,
+            assessmentCompletedStudentsCount: group.assessmentCompletedStudentsCount,
+            reportGeneratedStudentsCount: group.reportGeneratedStudentsCount,
+            studentsWithAssignedTasksCount: group.studentsWithAssignedTasksCount,
+            studentsWithCompletedTaskCount: group.studentsWithCompletedTaskCount,
+            studentsEligibleForActivitiesCount: group.studentsEligibleForActivitiesCount,
+            studentsParticipatedActivitiesCount: group.studentsParticipatedActivitiesCount
+          }).assessmentCompletionRate
+        )
+      },
+      {
+        code: "report_generation_rate",
+        name: "报告生成率",
+        values: groups.map((group) =>
+          calculateDashboardMetricRates({
+            activatedStudentsCount: group.activatedStudentsCount,
+            assessmentCompletedStudentsCount: group.assessmentCompletedStudentsCount,
+            reportGeneratedStudentsCount: group.reportGeneratedStudentsCount,
+            studentsWithAssignedTasksCount: group.studentsWithAssignedTasksCount,
+            studentsWithCompletedTaskCount: group.studentsWithCompletedTaskCount,
+            studentsEligibleForActivitiesCount: group.studentsEligibleForActivitiesCount,
+            studentsParticipatedActivitiesCount: group.studentsParticipatedActivitiesCount
+          }).reportGenerationRate
+        )
+      },
+      {
+        code: "task_completion_rate",
+        name: "任务完成率",
+        values: groups.map((group) =>
+          calculateDashboardMetricRates({
+            activatedStudentsCount: group.activatedStudentsCount,
+            assessmentCompletedStudentsCount: group.assessmentCompletedStudentsCount,
+            reportGeneratedStudentsCount: group.reportGeneratedStudentsCount,
+            studentsWithAssignedTasksCount: group.studentsWithAssignedTasksCount,
+            studentsWithCompletedTaskCount: group.studentsWithCompletedTaskCount,
+            studentsEligibleForActivitiesCount: group.studentsEligibleForActivitiesCount,
+            studentsParticipatedActivitiesCount: group.studentsParticipatedActivitiesCount
+          }).taskCompletionRate
+        )
+      },
+      {
+        code: "activity_participation_rate",
+        name: "活动参与率",
+        values: groups.map((group) =>
+          calculateDashboardMetricRates({
+            activatedStudentsCount: group.activatedStudentsCount,
+            assessmentCompletedStudentsCount: group.assessmentCompletedStudentsCount,
+            reportGeneratedStudentsCount: group.reportGeneratedStudentsCount,
+            studentsWithAssignedTasksCount: group.studentsWithAssignedTasksCount,
+            studentsWithCompletedTaskCount: group.studentsWithCompletedTaskCount,
+            studentsEligibleForActivitiesCount: group.studentsEligibleForActivitiesCount,
+            studentsParticipatedActivitiesCount: group.studentsParticipatedActivitiesCount
+          }).activityParticipationRate
+        )
+      }
+    ]
+  };
+};
+
+const createStackedBarChart = (
+  groups: GroupedMetricRecord[],
+  dimension: DashboardDimension
+): DashboardStackedBarChart => {
+  return {
+    dimension,
+    categories: groups.map((group) => group.name),
+    series: [
+      {
+        direction: "employment",
+        values: groups.map((group) => group.reportDirectionEmploymentCount)
+      },
+      {
+        direction: "postgraduate",
+        values: groups.map((group) => group.reportDirectionPostgraduateCount)
+      },
+      {
+        direction: "civil_service",
+        values: groups.map((group) => group.reportDirectionCivilServiceCount)
+      }
+    ]
+  };
+};
+
+export const createDashboardDimensionAggregationService = ({
+  dashboardMetricsRepo
+}: CreateDashboardDimensionAggregationServiceInput): DashboardDimensionAggregationService => {
+  return {
+    async aggregateByDimension({
+      dimension,
+      filters
+    }: AggregateByDimensionInput): Promise<DashboardDimensionAggregationResult> {
+      const records = await dashboardMetricsRepo.listClassMetricRecords(filters);
+      const groups = groupByDimension(records, dimension);
+
+      return {
+        dictionaryVersion: METRICS_DICTIONARY_VERSION,
+        dimension,
+        metricCards: createMetricCards(records),
+        barChart: createBarChart(groups, dimension),
+        stackedBarChart: createStackedBarChart(groups, dimension)
+      };
+    }
+  };
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -3,6 +3,11 @@ import type { ActivityService, ActivityType } from "../modules/activity/service.
 import type { AuditLogService } from "../modules/audit/service.js";
 import type { AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
 import {
+  type DashboardDimension,
+  type DashboardDimensionAggregationService,
+  type DashboardFilters
+} from "../modules/metrics/aggregation.js";
+import {
   MissingImportFileError,
   UnsupportedExcelFileTypeError,
   type ExcelImportValidationService,
@@ -39,6 +44,10 @@ export interface AdminRouteDependencies {
     "logAuthorizationGrant" | "logAuthorizationRevoke" | "logPasswordReset" | "logActivityPublish"
   >;
   excelImportValidationService?: Pick<ExcelImportValidationService, "validateExcelImport">;
+  dashboardDimensionAggregationService?: Pick<
+    DashboardDimensionAggregationService,
+    "aggregateByDimension"
+  >;
   adminApiKey: string;
 }
 
@@ -109,6 +118,23 @@ const isForbiddenByAdminKey = (requestAdminKey: string | undefined, adminApiKey:
   return !requestAdminKey || requestAdminKey !== adminApiKey;
 };
 
+const isDashboardDimension = (dimension: unknown): dimension is DashboardDimension => {
+  return dimension === "college" || dimension === "major" || dimension === "class";
+};
+
+const parsePositiveIntegerQuery = (raw: string | undefined): number | undefined | null => {
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  if (!/^[1-9]\d*$/.test(raw)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+};
+
 const isImportDatasetType = (datasetType: unknown): datasetType is ImportDatasetType => {
   return datasetType === "enrollment" || datasetType === "employment";
 };
@@ -166,12 +192,22 @@ const defaultExcelImportValidationService: Pick<ExcelImportValidationService, "v
   }
 };
 
+const defaultDashboardDimensionAggregationService: Pick<
+  DashboardDimensionAggregationService,
+  "aggregateByDimension"
+> = {
+  async aggregateByDimension() {
+    throw new Error("dashboardDimensionAggregationService is not configured");
+  }
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
   authorizationGrantService,
   activityService,
   auditLogService,
   excelImportValidationService = defaultExcelImportValidationService,
+  dashboardDimensionAggregationService = defaultDashboardDimensionAggregationService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
@@ -367,6 +403,41 @@ export const createAdminRoutes = ({
 
       throw error;
     }
+  });
+
+  admin.get("/dashboard/dimension-aggregation", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const dimensionQuery = c.req.query("dimension");
+    if (!isDashboardDimension(dimensionQuery)) {
+      return c.json({ message: "dimension must be college/major/class" }, 400);
+    }
+
+    const schoolId = parsePositiveIntegerQuery(c.req.query("schoolId"));
+    const collegeId = parsePositiveIntegerQuery(c.req.query("collegeId"));
+    const majorId = parsePositiveIntegerQuery(c.req.query("majorId"));
+    const classId = parsePositiveIntegerQuery(c.req.query("classId"));
+
+    if ([schoolId, collegeId, majorId, classId].some((value) => value === null)) {
+      return c.json({ message: "organization filter must be positive integer" }, 400);
+    }
+
+    const filters: DashboardFilters = {
+      schoolId: schoolId as number | undefined,
+      collegeId: collegeId as number | undefined,
+      majorId: majorId as number | undefined,
+      classId: classId as number | undefined
+    };
+
+    const result = await dashboardDimensionAggregationService.aggregateByDimension({
+      dimension: dimensionQuery,
+      filters
+    });
+
+    return c.json(result, 200);
   });
 
   return admin;

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,26 +18,26 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 6, "journal should contain at least 6 entries");
+  assert.ok(entries.length >= 7, "journal should contain at least 7 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
     );
   }
 
-  const snapshot0004 = readJson(path.join(drizzleMetaDir, "0004_snapshot.json"));
   const snapshot0005 = readJson(path.join(drizzleMetaDir, "0005_snapshot.json"));
+  const snapshot0006 = readJson(path.join(drizzleMetaDir, "0006_snapshot.json"));
 
   assert.equal(
-    snapshot0005.prevId,
-    snapshot0004.id,
-    "0005 snapshot prevId should point to 0004 snapshot id"
+    snapshot0006.prevId,
+    snapshot0005.id,
+    "0006 snapshot prevId should point to 0005 snapshot id"
   );
 });
 
@@ -116,4 +116,17 @@ test("0005 migration file should exist and include certificate_files table", () 
     /CREATE TABLE\s+`certificate_files`/i,
     "0005 migration should create table certificate_files"
   );
+});
+
+test("0006 migration file should include major dimension and report direction updates", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0006 = migrationFiles.find((fileName) => /^0006_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0006, "expected a 0006 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0006), "utf8");
+
+  assert.match(migrationSql, /CREATE TABLE\s+`majors`/i);
+  assert.match(migrationSql, /ADD\s+`major_id`\s+int/i);
+  assert.match(migrationSql, /ADD\s+`direction`/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -5,7 +5,10 @@ import {
   authScopes,
   auditLogs,
   certificateFiles,
+  classes,
   certificates,
+  colleges,
+  majors,
   profiles,
   reports,
   roleScopes,
@@ -78,4 +81,11 @@ test("schema should include certificate_files metadata table", () => {
   assert.equal(certificateFiles.mimeType.name, "mime_type");
   assert.equal(certificateFiles.sizeBytes.name, "size_bytes");
   assert.equal(certificateFiles.storagePath.name, "storage_path");
+});
+
+test("schema should include major dimension and report direction fields", () => {
+  assert.equal(majors[Symbol.for("drizzle:Name")], "majors");
+  assert.equal(classes.majorId.name, "major_id");
+  assert.equal(colleges.schoolId.name, "school_id");
+  assert.equal(reports.direction.name, "direction");
 });

--- a/tests/metrics/admin-dimension-aggregation.test.ts
+++ b/tests/metrics/admin-dimension-aggregation.test.ts
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+
+const adminApiKey = "admin-secret-key";
+
+interface CallSnapshot {
+  dimension: string;
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+}
+
+const createApp = (calls: CallSnapshot[] = []) => {
+  const app = new Hono();
+
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      authorizationGrantService: {
+        async assignGrant() {
+          return;
+        },
+        async revokeGrant() {
+          return;
+        }
+      },
+      activityService: {
+        async publishActivity() {
+          return;
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          return;
+        },
+        async logAuthorizationRevoke() {
+          return;
+        },
+        async logPasswordReset() {
+          return;
+        },
+        async logActivityPublish() {
+          return;
+        }
+      },
+      excelImportValidationService: {
+        async validateExcelImport() {
+          return { total: 0, success: 0, failed: 0, errors: [] };
+        }
+      },
+      dashboardDimensionAggregationService: {
+        async aggregateByDimension(input) {
+          calls.push({
+            dimension: input.dimension,
+            schoolId: input.filters.schoolId,
+            collegeId: input.filters.collegeId,
+            majorId: input.filters.majorId,
+            classId: input.filters.classId
+          });
+          return {
+            dictionaryVersion: "b07.v1",
+            dimension: input.dimension,
+            metricCards: {
+              activatedStudentsCount: 100,
+              assessmentCompletionRate: 0.8,
+              reportGenerationRate: 0.7,
+              taskCompletionRate: 0.5,
+              activityParticipationRate: 0.3
+            },
+            barChart: {
+              dimension: input.dimension,
+              categories: ["信息工程学院"],
+              series: []
+            },
+            stackedBarChart: {
+              dimension: input.dimension,
+              categories: ["信息工程学院"],
+              series: []
+            }
+          };
+        }
+      },
+      adminApiKey
+    })
+  );
+
+  return app;
+};
+
+test("admin dashboard aggregation should return 403 without admin key", async () => {
+  const app = createApp();
+
+  const response = await app.request("/admin/dashboard/dimension-aggregation?dimension=college");
+
+  assert.equal(response.status, 403);
+});
+
+test("admin dashboard aggregation should return 400 for invalid dimension", async () => {
+  const app = createApp();
+
+  const response = await app.request("/admin/dashboard/dimension-aggregation?dimension=invalid", {
+    headers: {
+      "X-Admin-Key": adminApiKey
+    }
+  });
+
+  assert.equal(response.status, 400);
+});
+
+test("admin dashboard aggregation should return aggregated payload", async () => {
+  const calls: CallSnapshot[] = [];
+  const app = createApp(calls);
+
+  const response = await app.request(
+    "/admin/dashboard/dimension-aggregation?dimension=college&schoolId=1&collegeId=10",
+    {
+      headers: {
+        "X-Admin-Key": adminApiKey
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    dictionaryVersion: string;
+    metricCards: { activatedStudentsCount: number };
+  };
+
+  assert.equal(body.dictionaryVersion, "b07.v1");
+  assert.equal(body.metricCards.activatedStudentsCount, 100);
+  assert.deepEqual(calls, [
+    {
+      dimension: "college",
+      schoolId: 1,
+      collegeId: 10,
+      majorId: undefined,
+      classId: undefined
+    }
+  ]);
+});
+
+test("admin dashboard aggregation should return 400 for invalid filter format", async () => {
+  const app = createApp();
+
+  const response = await app.request(
+    "/admin/dashboard/dimension-aggregation?dimension=major&schoolId=abc",
+    {
+      headers: {
+        "X-Admin-Key": adminApiKey
+      }
+    }
+  );
+
+  assert.equal(response.status, 400);
+});

--- a/tests/metrics/dashboard-aggregation.test.ts
+++ b/tests/metrics/dashboard-aggregation.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createDashboardDimensionAggregationService,
+  type DashboardMetricsRepository
+} from "../../src/modules/metrics/aggregation.ts";
+
+const repository: DashboardMetricsRepository = {
+  async listClassMetricRecords() {
+    return [
+      {
+        schoolId: 1,
+        collegeId: 10,
+        collegeName: "信息工程学院",
+        majorId: 100,
+        majorName: "软件工程",
+        classId: 1000,
+        className: "软工1班",
+        activatedStudentsCount: 40,
+        assessmentCompletedStudentsCount: 20,
+        reportGeneratedStudentsCount: 10,
+        studentsWithAssignedTasksCount: 10,
+        studentsWithCompletedTaskCount: 5,
+        studentsEligibleForActivitiesCount: 20,
+        studentsParticipatedActivitiesCount: 4,
+        reportDirectionEmploymentCount: 6,
+        reportDirectionPostgraduateCount: 3,
+        reportDirectionCivilServiceCount: 1
+      },
+      {
+        schoolId: 1,
+        collegeId: 10,
+        collegeName: "信息工程学院",
+        majorId: 101,
+        majorName: "网络工程",
+        classId: 1001,
+        className: "网工1班",
+        activatedStudentsCount: 30,
+        assessmentCompletedStudentsCount: 15,
+        reportGeneratedStudentsCount: 9,
+        studentsWithAssignedTasksCount: 12,
+        studentsWithCompletedTaskCount: 6,
+        studentsEligibleForActivitiesCount: 15,
+        studentsParticipatedActivitiesCount: 5,
+        reportDirectionEmploymentCount: 4,
+        reportDirectionPostgraduateCount: 2,
+        reportDirectionCivilServiceCount: 3
+      },
+      {
+        schoolId: 1,
+        collegeId: 11,
+        collegeName: "经济管理学院",
+        majorId: 110,
+        majorName: "工商管理",
+        classId: 1101,
+        className: "工商1班",
+        activatedStudentsCount: 20,
+        assessmentCompletedStudentsCount: 10,
+        reportGeneratedStudentsCount: 8,
+        studentsWithAssignedTasksCount: 8,
+        studentsWithCompletedTaskCount: 4,
+        studentsEligibleForActivitiesCount: 10,
+        studentsParticipatedActivitiesCount: 3,
+        reportDirectionEmploymentCount: 4,
+        reportDirectionPostgraduateCount: 2,
+        reportDirectionCivilServiceCount: 2
+      }
+    ];
+  }
+};
+
+test("dashboard aggregation should return metric cards and chart data by dimension", async () => {
+  const service = createDashboardDimensionAggregationService({
+    dashboardMetricsRepo: repository
+  });
+
+  const result = await service.aggregateByDimension({
+    dimension: "college",
+    filters: {
+      schoolId: 1
+    }
+  });
+
+  assert.equal(result.metricCards.activatedStudentsCount, 90);
+  assert.equal(result.barChart.dimension, "college");
+  assert.deepEqual(result.barChart.categories, ["信息工程学院", "经济管理学院"]);
+
+  const stackedSeries = result.stackedBarChart.series;
+  assert.equal(stackedSeries.length, 3);
+  assert.equal(stackedSeries[0].direction, "employment");
+  assert.deepEqual(stackedSeries[0].values, [10, 4]);
+});
+


### PR DESCRIPTION
## 背景
实现 B08：驾驶舱维度聚合 API（院系/专业/班级 + 指标卡 + 柱状/堆叠柱）。

## 变更内容
- 新增聚合服务：`src/modules/metrics/aggregation.ts`
  - 支持按 `college/major/class` 聚合
  - 产出指标卡、柱状图、堆叠柱数据结构
- 新增接口：`GET /admin/dashboard/dimension-aggregation`
  - 支持 `dimension` 参数
  - 支持组织筛选：`schoolId/collegeId/majorId/classId`
- 补齐专业维度模型：
  - 新增 `majors` 表
  - `classes` 增加 `major_id`
  - `reports` 增加 `direction`（employment/postgraduate/civil_service）
- 新增迁移：`drizzle/0006_warm_lester.sql`
- 新增测试：
  - `tests/metrics/dashboard-aggregation.test.ts`
  - `tests/metrics/admin-dimension-aggregation.test.ts`
  - `tests/db/schema.test.ts`
  - `tests/db/migrations.test.ts`

## 验证
- [x] `npm test`
- [x] `npm run check`
- [x] `npm run build`

Closes #10
