### PR TITLE
feat(metrics): 新增驾驶舱趋势与漏斗 API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "@hono/node-server";
-import { and, eq } from "drizzle-orm";
+import { and, eq, gte, lt } from "drizzle-orm";
 import { Hono } from "hono";
 import path from "node:path";
 import { env } from "./config/env.js";
@@ -25,6 +25,10 @@ import { createActivityService } from "./modules/activity/service.js";
 import { createAuditLogService } from "./modules/audit/service.js";
 import { createAuthorizationGrantService } from "./modules/authorization/grant-service.js";
 import { createDashboardDimensionAggregationService } from "./modules/metrics/aggregation.js";
+import {
+  createDashboardTrendFunnelService,
+  type DashboardTrendFunnelQueryInput
+} from "./modules/metrics/trend-funnel.js";
 import { createResourceAuthorizationService, type ResourceType } from "./modules/authorization/service.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
@@ -402,6 +406,178 @@ const dashboardDimensionAggregationService = createDashboardDimensionAggregation
   dashboardMetricsRepo
 });
 
+const toDateOnlyString = (value: Date | string): string => {
+  if (value instanceof Date) {
+    const year = value.getUTCFullYear();
+    const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(value.getUTCDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  }
+
+  return value.slice(0, 10);
+};
+
+const toUtcDate = (dateOnly: string): Date => {
+  return new Date(`${dateOnly}T00:00:00.000Z`);
+};
+
+const buildTrendFunnelConditions = (
+  filters: DashboardTrendFunnelQueryInput["filters"]
+) => {
+  const conditions = [];
+
+  if (filters.schoolId) {
+    conditions.push(eq(colleges.schoolId, filters.schoolId));
+  }
+  if (filters.collegeId) {
+    conditions.push(eq(classes.collegeId, filters.collegeId));
+  }
+  if (filters.majorId) {
+    conditions.push(eq(classes.majorId, filters.majorId));
+  }
+  if (filters.classId) {
+    conditions.push(eq(classes.id, filters.classId));
+  }
+
+  return conditions;
+};
+
+const dashboardTrendFunnelRepo = {
+  async listActivatedStudents({ filters, dateRange }: DashboardTrendFunnelQueryInput) {
+    const endExclusiveDate = toUtcDate(dateRange.endDate);
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+
+    const rows = await db
+      .select({
+        studentId: students.id,
+        createdAt: students.createdAt
+      })
+      .from(students)
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .where(
+        and(
+          ...buildTrendFunnelConditions(filters),
+          gte(students.createdAt, toUtcDate(dateRange.startDate)),
+          lt(students.createdAt, endExclusiveDate)
+        )
+      );
+
+    return rows.map((row) => ({
+      studentId: row.studentId,
+      date: toDateOnlyString(row.createdAt)
+    }));
+  },
+  async listAssessmentCompletedStudents({ filters, dateRange }: DashboardTrendFunnelQueryInput) {
+    const endExclusiveDate = toUtcDate(dateRange.endDate);
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+
+    const rows = await db
+      .select({
+        studentId: profiles.studentId,
+        createdAt: profiles.createdAt
+      })
+      .from(profiles)
+      .innerJoin(students, eq(profiles.studentId, students.id))
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .where(
+        and(
+          ...buildTrendFunnelConditions(filters),
+          gte(profiles.createdAt, toUtcDate(dateRange.startDate)),
+          lt(profiles.createdAt, endExclusiveDate)
+        )
+      );
+
+    return rows.map((row) => ({
+      studentId: row.studentId,
+      date: toDateOnlyString(row.createdAt)
+    }));
+  },
+  async listReportGeneratedStudents({ filters, dateRange }: DashboardTrendFunnelQueryInput) {
+    const endExclusiveDate = toUtcDate(dateRange.endDate);
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+
+    const rows = await db
+      .select({
+        studentId: reports.studentId,
+        createdAt: reports.createdAt
+      })
+      .from(reports)
+      .innerJoin(students, eq(reports.studentId, students.id))
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .where(
+        and(
+          ...buildTrendFunnelConditions(filters),
+          gte(reports.createdAt, toUtcDate(dateRange.startDate)),
+          lt(reports.createdAt, endExclusiveDate)
+        )
+      );
+
+    return rows.map((row) => ({
+      studentId: row.studentId,
+      date: toDateOnlyString(row.createdAt)
+    }));
+  },
+  async listTaskCompletedStudents({ filters, dateRange }: DashboardTrendFunnelQueryInput) {
+    const endExclusiveDate = toUtcDate(dateRange.endDate);
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+
+    const rows = await db
+      .select({
+        studentId: tasks.studentId,
+        createdAt: tasks.createdAt
+      })
+      .from(tasks)
+      .innerJoin(students, eq(tasks.studentId, students.id))
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .where(
+        and(
+          ...buildTrendFunnelConditions(filters),
+          gte(tasks.createdAt, toUtcDate(dateRange.startDate)),
+          lt(tasks.createdAt, endExclusiveDate)
+        )
+      );
+
+    return rows.map((row) => ({
+      studentId: row.studentId,
+      date: toDateOnlyString(row.createdAt)
+    }));
+  },
+  async listActivityParticipatedStudents({ filters, dateRange }: DashboardTrendFunnelQueryInput) {
+    const endExclusiveDate = toUtcDate(dateRange.endDate);
+    endExclusiveDate.setUTCDate(endExclusiveDate.getUTCDate() + 1);
+
+    const rows = await db
+      .select({
+        studentId: certificates.studentId,
+        createdAt: certificates.createdAt
+      })
+      .from(certificates)
+      .innerJoin(students, eq(certificates.studentId, students.id))
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .where(
+        and(
+          ...buildTrendFunnelConditions(filters),
+          gte(certificates.createdAt, toUtcDate(dateRange.startDate)),
+          lt(certificates.createdAt, endExclusiveDate)
+        )
+      );
+
+    return rows.map((row) => ({
+      studentId: row.studentId,
+      date: toDateOnlyString(row.createdAt)
+    }));
+  }
+};
+
+const dashboardTrendFunnelService = createDashboardTrendFunnelService({
+  dashboardTrendFunnelRepo
+});
+
 const certificateFileRepo = {
   async createCertificateFile({
     fileId,
@@ -463,6 +639,7 @@ app.route(
     auditLogService,
     excelImportValidationService,
     dashboardDimensionAggregationService,
+    dashboardTrendFunnelService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/modules/metrics/trend-funnel.ts
+++ b/src/modules/metrics/trend-funnel.ts
@@ -1,0 +1,294 @@
+import type { DashboardFilters } from "./aggregation.js";
+import {
+  METRICS_DICTIONARY_VERSION,
+  calculateConversionFunnel,
+  type ConversionFunnelStageResult
+} from "./dictionary.js";
+
+const DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export interface DashboardDateRange {
+  startDate: string;
+  endDate: string;
+}
+
+export interface DashboardMetricStudentDateRecord {
+  studentId: number;
+  date: string;
+}
+
+export interface DashboardTrendFunnelQueryInput {
+  filters: DashboardFilters;
+  dateRange: DashboardDateRange;
+}
+
+export interface DashboardTrendFunnelRepository {
+  listActivatedStudents(
+    input: DashboardTrendFunnelQueryInput
+  ): Promise<DashboardMetricStudentDateRecord[]>;
+  listAssessmentCompletedStudents(
+    input: DashboardTrendFunnelQueryInput
+  ): Promise<DashboardMetricStudentDateRecord[]>;
+  listReportGeneratedStudents(
+    input: DashboardTrendFunnelQueryInput
+  ): Promise<DashboardMetricStudentDateRecord[]>;
+  listTaskCompletedStudents(
+    input: DashboardTrendFunnelQueryInput
+  ): Promise<DashboardMetricStudentDateRecord[]>;
+  listActivityParticipatedStudents(
+    input: DashboardTrendFunnelQueryInput
+  ): Promise<DashboardMetricStudentDateRecord[]>;
+}
+
+export interface DashboardTrendPoint {
+  date: string;
+  activatedStudentsCount: number;
+  assessmentCompletedStudentsCount: number;
+  reportGeneratedStudentsCount: number;
+  taskCompletedStudentsCount: number;
+  activityParticipatedStudentsCount: number;
+}
+
+export interface DashboardTrendFunnelResult {
+  dictionaryVersion: string;
+  dateRange: DashboardDateRange;
+  trend: DashboardTrendPoint[];
+  funnel: ConversionFunnelStageResult[];
+}
+
+export interface GetDashboardTrendFunnelInput {
+  filters: DashboardFilters;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface DashboardTrendFunnelService {
+  getTrendAndFunnel(input: GetDashboardTrendFunnelInput): Promise<DashboardTrendFunnelResult>;
+}
+
+export interface CreateDashboardTrendFunnelServiceInput {
+  dashboardTrendFunnelRepo: DashboardTrendFunnelRepository;
+  nowProvider?: () => Date;
+}
+
+export class InvalidDashboardDateRangeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidDashboardDateRangeError";
+  }
+}
+
+const parseDateOnly = (rawDate: string): Date | null => {
+  const matched = DATE_PATTERN.exec(rawDate);
+  if (!matched) {
+    return null;
+  }
+
+  const year = Number.parseInt(matched[1], 10);
+  const month = Number.parseInt(matched[2], 10);
+  const day = Number.parseInt(matched[3], 10);
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  const isValidDate =
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day;
+
+  return isValidDate ? date : null;
+};
+
+const formatDateOnly = (date: Date): string => {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const addDays = (date: Date, days: number): Date => {
+  return new Date(date.getTime() + days * 24 * 60 * 60 * 1000);
+};
+
+const resolveDateRange = ({
+  startDate,
+  endDate,
+  nowProvider
+}: {
+  startDate?: string;
+  endDate?: string;
+  nowProvider: () => Date;
+}): DashboardDateRange => {
+  const today = formatDateOnly(nowProvider());
+  const resolvedEndDate = endDate ?? today;
+  const parsedEndDate = parseDateOnly(resolvedEndDate);
+
+  if (!parsedEndDate) {
+    throw new InvalidDashboardDateRangeError("endDate must be YYYY-MM-DD");
+  }
+
+  const resolvedStartDate =
+    startDate ?? formatDateOnly(addDays(new Date(parsedEndDate.getTime()), -29));
+  const parsedStartDate = parseDateOnly(resolvedStartDate);
+
+  if (!parsedStartDate) {
+    throw new InvalidDashboardDateRangeError("startDate must be YYYY-MM-DD");
+  }
+
+  if (parsedStartDate.getTime() > parsedEndDate.getTime()) {
+    throw new InvalidDashboardDateRangeError("startDate must be less than or equal to endDate");
+  }
+
+  return {
+    startDate: resolvedStartDate,
+    endDate: resolvedEndDate
+  };
+};
+
+const listDates = (dateRange: DashboardDateRange): string[] => {
+  const start = parseDateOnly(dateRange.startDate);
+  const end = parseDateOnly(dateRange.endDate);
+
+  if (!start || !end) {
+    return [];
+  }
+
+  const dates: string[] = [];
+  let cursor = new Date(start.getTime());
+
+  while (cursor.getTime() <= end.getTime()) {
+    dates.push(formatDateOnly(cursor));
+    cursor = addDays(cursor, 1);
+  }
+
+  return dates;
+};
+
+const createEmptyTrendPoint = (date: string): DashboardTrendPoint => ({
+  date,
+  activatedStudentsCount: 0,
+  assessmentCompletedStudentsCount: 0,
+  reportGeneratedStudentsCount: 0,
+  taskCompletedStudentsCount: 0,
+  activityParticipatedStudentsCount: 0
+});
+
+const countByDate = (
+  records: DashboardMetricStudentDateRecord[],
+  trendMap: Map<string, DashboardTrendPoint>,
+  updater: (point: DashboardTrendPoint) => void
+): void => {
+  const seen = new Set<string>();
+
+  for (const record of records) {
+    const point = trendMap.get(record.date);
+    if (!point) {
+      continue;
+    }
+
+    const dedupeKey = `${record.date}:${record.studentId}`;
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+
+    seen.add(dedupeKey);
+    updater(point);
+  }
+};
+
+const countDistinctStudents = (
+  records: DashboardMetricStudentDateRecord[],
+  includedDateSet: Set<string>
+): number => {
+  const students = new Set<number>();
+
+  for (const record of records) {
+    if (!includedDateSet.has(record.date)) {
+      continue;
+    }
+
+    students.add(record.studentId);
+  }
+
+  return students.size;
+};
+
+export const createDashboardTrendFunnelService = ({
+  dashboardTrendFunnelRepo,
+  nowProvider = () => new Date()
+}: CreateDashboardTrendFunnelServiceInput): DashboardTrendFunnelService => {
+  return {
+    async getTrendAndFunnel({
+      filters,
+      startDate,
+      endDate
+    }: GetDashboardTrendFunnelInput): Promise<DashboardTrendFunnelResult> {
+      const dateRange = resolveDateRange({
+        startDate,
+        endDate,
+        nowProvider
+      });
+
+      const queryInput: DashboardTrendFunnelQueryInput = {
+        filters,
+        dateRange
+      };
+
+      const [
+        activatedStudents,
+        assessmentCompletedStudents,
+        reportGeneratedStudents,
+        taskCompletedStudents,
+        activityParticipatedStudents
+      ] = await Promise.all([
+        dashboardTrendFunnelRepo.listActivatedStudents(queryInput),
+        dashboardTrendFunnelRepo.listAssessmentCompletedStudents(queryInput),
+        dashboardTrendFunnelRepo.listReportGeneratedStudents(queryInput),
+        dashboardTrendFunnelRepo.listTaskCompletedStudents(queryInput),
+        dashboardTrendFunnelRepo.listActivityParticipatedStudents(queryInput)
+      ]);
+
+      const dateSeries = listDates(dateRange);
+      const trendMap = new Map<string, DashboardTrendPoint>(
+        dateSeries.map((date) => [date, createEmptyTrendPoint(date)])
+      );
+
+      countByDate(activatedStudents, trendMap, (point) => {
+        point.activatedStudentsCount += 1;
+      });
+      countByDate(assessmentCompletedStudents, trendMap, (point) => {
+        point.assessmentCompletedStudentsCount += 1;
+      });
+      countByDate(reportGeneratedStudents, trendMap, (point) => {
+        point.reportGeneratedStudentsCount += 1;
+      });
+      countByDate(taskCompletedStudents, trendMap, (point) => {
+        point.taskCompletedStudentsCount += 1;
+      });
+      countByDate(activityParticipatedStudents, trendMap, (point) => {
+        point.activityParticipatedStudentsCount += 1;
+      });
+
+      const includedDateSet = new Set(dateSeries);
+      const funnel = calculateConversionFunnel({
+        activatedStudentsCount: countDistinctStudents(activatedStudents, includedDateSet),
+        assessmentCompletedStudentsCount: countDistinctStudents(
+          assessmentCompletedStudents,
+          includedDateSet
+        ),
+        reportGeneratedStudentsCount: countDistinctStudents(reportGeneratedStudents, includedDateSet),
+        studentsWithCompletedTaskCount: countDistinctStudents(taskCompletedStudents, includedDateSet),
+        studentsParticipatedActivitiesCount: countDistinctStudents(
+          activityParticipatedStudents,
+          includedDateSet
+        )
+      });
+
+      return {
+        dictionaryVersion: METRICS_DICTIONARY_VERSION,
+        dateRange,
+        trend: dateSeries.map((date) => trendMap.get(date) ?? createEmptyTrendPoint(date)),
+        funnel
+      };
+    }
+  };
+};

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -8,6 +8,10 @@ import {
   type DashboardFilters
 } from "../modules/metrics/aggregation.js";
 import {
+  InvalidDashboardDateRangeError,
+  type DashboardTrendFunnelService
+} from "../modules/metrics/trend-funnel.js";
+import {
   MissingImportFileError,
   UnsupportedExcelFileTypeError,
   type ExcelImportValidationService,
@@ -48,6 +52,7 @@ export interface AdminRouteDependencies {
     DashboardDimensionAggregationService,
     "aggregateByDimension"
   >;
+  dashboardTrendFunnelService?: Pick<DashboardTrendFunnelService, "getTrendAndFunnel">;
   adminApiKey: string;
 }
 
@@ -135,6 +140,26 @@ const parsePositiveIntegerQuery = (raw: string | undefined): number | undefined 
   return Number.isSafeInteger(parsed) ? parsed : null;
 };
 
+const DASHBOARD_DATE_QUERY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const isValidDateOnly = (rawDate: string): boolean => {
+  const matched = DASHBOARD_DATE_QUERY_PATTERN.exec(rawDate);
+  if (!matched) {
+    return false;
+  }
+
+  const year = Number.parseInt(matched[1], 10);
+  const month = Number.parseInt(matched[2], 10);
+  const day = Number.parseInt(matched[3], 10);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() + 1 === month &&
+    date.getUTCDate() === day
+  );
+};
+
 const isImportDatasetType = (datasetType: unknown): datasetType is ImportDatasetType => {
   return datasetType === "enrollment" || datasetType === "employment";
 };
@@ -201,6 +226,12 @@ const defaultDashboardDimensionAggregationService: Pick<
   }
 };
 
+const defaultDashboardTrendFunnelService: Pick<DashboardTrendFunnelService, "getTrendAndFunnel"> = {
+  async getTrendAndFunnel() {
+    throw new Error("dashboardTrendFunnelService is not configured");
+  }
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
   authorizationGrantService,
@@ -208,6 +239,7 @@ export const createAdminRoutes = ({
   auditLogService,
   excelImportValidationService = defaultExcelImportValidationService,
   dashboardDimensionAggregationService = defaultDashboardDimensionAggregationService,
+  dashboardTrendFunnelService = defaultDashboardTrendFunnelService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
@@ -438,6 +470,56 @@ export const createAdminRoutes = ({
     });
 
     return c.json(result, 200);
+  });
+
+  admin.get("/dashboard/trend-funnel", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const schoolId = parsePositiveIntegerQuery(c.req.query("schoolId"));
+    const collegeId = parsePositiveIntegerQuery(c.req.query("collegeId"));
+    const majorId = parsePositiveIntegerQuery(c.req.query("majorId"));
+    const classId = parsePositiveIntegerQuery(c.req.query("classId"));
+
+    if ([schoolId, collegeId, majorId, classId].some((value) => value === null)) {
+      return c.json({ message: "organization filter must be positive integer" }, 400);
+    }
+
+    const startDate = c.req.query("startDate");
+    const endDate = c.req.query("endDate");
+
+    if ((startDate && !isValidDateOnly(startDate)) || (endDate && !isValidDateOnly(endDate))) {
+      return c.json({ message: "startDate/endDate must be YYYY-MM-DD" }, 400);
+    }
+
+    if (startDate && endDate && startDate > endDate) {
+      return c.json({ message: "startDate must be less than or equal to endDate" }, 400);
+    }
+
+    const filters: DashboardFilters = {
+      schoolId: schoolId as number | undefined,
+      collegeId: collegeId as number | undefined,
+      majorId: majorId as number | undefined,
+      classId: classId as number | undefined
+    };
+
+    try {
+      const result = await dashboardTrendFunnelService.getTrendAndFunnel({
+        filters,
+        startDate,
+        endDate
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof InvalidDashboardDateRangeError) {
+        return c.json({ message: error.message }, 400);
+      }
+
+      throw error;
+    }
   });
 
   return admin;

--- a/tests/metrics/admin-trend-funnel.test.ts
+++ b/tests/metrics/admin-trend-funnel.test.ts
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+
+const adminApiKey = "admin-secret-key";
+
+const createApp = () => {
+  const app = new Hono();
+
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      authorizationGrantService: {
+        async assignGrant() {
+          return;
+        },
+        async revokeGrant() {
+          return;
+        }
+      },
+      activityService: {
+        async publishActivity() {
+          return;
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          return;
+        },
+        async logAuthorizationRevoke() {
+          return;
+        },
+        async logPasswordReset() {
+          return;
+        },
+        async logActivityPublish() {
+          return;
+        }
+      },
+      excelImportValidationService: {
+        async validateExcelImport() {
+          return { total: 0, success: 0, failed: 0, errors: [] };
+        }
+      },
+      dashboardDimensionAggregationService: {
+        async aggregateByDimension() {
+          return {
+            dictionaryVersion: "b07.v1",
+            dimension: "college" as const,
+            metricCards: {
+              activatedStudentsCount: 0,
+              assessmentCompletionRate: 0,
+              reportGenerationRate: 0,
+              taskCompletionRate: 0,
+              activityParticipationRate: 0
+            },
+            barChart: { dimension: "college" as const, categories: [], series: [] },
+            stackedBarChart: { dimension: "college" as const, categories: [], series: [] }
+          };
+        }
+      },
+      dashboardTrendFunnelService: {
+        async getTrendAndFunnel() {
+          return {
+            dictionaryVersion: "b07.v1",
+            dateRange: {
+              startDate: "2026-02-01",
+              endDate: "2026-03-02"
+            },
+            trend: [],
+            funnel: []
+          };
+        }
+      },
+      adminApiKey
+    })
+  );
+
+  return app;
+};
+
+test("admin trend-funnel should return 403 without admin key", async () => {
+  const app = createApp();
+  const response = await app.request("/admin/dashboard/trend-funnel");
+  assert.equal(response.status, 403);
+});
+
+test("admin trend-funnel should return 400 when date range is invalid", async () => {
+  const app = createApp();
+  const response = await app.request(
+    "/admin/dashboard/trend-funnel?startDate=2026-03-10&endDate=2026-03-02",
+    { headers: { "X-Admin-Key": adminApiKey } }
+  );
+  assert.equal(response.status, 400);
+});
+
+test("admin trend-funnel should return trend and funnel payload", async () => {
+  const app = createApp();
+  const response = await app.request(
+    "/admin/dashboard/trend-funnel?schoolId=1&collegeId=2&startDate=2026-02-01&endDate=2026-03-02",
+    { headers: { "X-Admin-Key": adminApiKey } }
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { dictionaryVersion: string };
+  assert.equal(body.dictionaryVersion, "b07.v1");
+});

--- a/tests/metrics/dashboard-trend-funnel.test.ts
+++ b/tests/metrics/dashboard-trend-funnel.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createDashboardTrendFunnelService,
+  type DashboardTrendFunnelRepository
+} from "../../src/modules/metrics/trend-funnel.ts";
+
+const repository: DashboardTrendFunnelRepository = {
+  async listActivatedStudents() {
+    return [
+      { studentId: 1, date: "2026-03-01" },
+      { studentId: 2, date: "2026-03-02" },
+      { studentId: 3, date: "2026-03-04" }
+    ];
+  },
+  async listAssessmentCompletedStudents() {
+    return [
+      { studentId: 1, date: "2026-03-02" },
+      { studentId: 2, date: "2026-03-04" }
+    ];
+  },
+  async listReportGeneratedStudents() {
+    return [{ studentId: 1, date: "2026-03-03" }];
+  },
+  async listTaskCompletedStudents() {
+    return [{ studentId: 1, date: "2026-03-04" }];
+  },
+  async listActivityParticipatedStudents() {
+    return [{ studentId: 1, date: "2026-03-04" }];
+  }
+};
+
+test("trend-funnel service should return continuous date trend and fixed-order funnel", async () => {
+  const service = createDashboardTrendFunnelService({
+    dashboardTrendFunnelRepo: repository,
+    nowProvider: () => new Date("2026-03-04T00:00:00Z")
+  });
+
+  const result = await service.getTrendAndFunnel({
+    filters: {},
+    startDate: "2026-03-01",
+    endDate: "2026-03-04"
+  });
+
+  assert.equal(result.dictionaryVersion, "b07.v1");
+  assert.equal(result.trend.length, 4);
+  assert.deepEqual(
+    result.trend.map((item) => item.date),
+    ["2026-03-01", "2026-03-02", "2026-03-03", "2026-03-04"]
+  );
+
+  const day4 = result.trend[3];
+  assert.equal(day4.activatedStudentsCount, 1);
+  assert.equal(day4.assessmentCompletedStudentsCount, 1);
+  assert.equal(day4.reportGeneratedStudentsCount, 0);
+  assert.equal(day4.taskCompletedStudentsCount, 1);
+  assert.equal(day4.activityParticipatedStudentsCount, 1);
+
+  assert.deepEqual(
+    result.funnel.map((stage) => stage.stageCode),
+    [
+      "activated_students",
+      "assessment_completed_students",
+      "report_generated_students",
+      "task_completed_students",
+      "activity_participated_students"
+    ]
+  );
+});


### PR DESCRIPTION
## 变更说明
完成 B09「驾驶舱趋势与漏斗 API（30天折线 + 转化漏斗）」：

- 新增 `src/modules/metrics/trend-funnel.ts`
  - 聚合趋势与漏斗数据
  - 支持组织过滤参数：`schoolId/collegeId/majorId/classId`
  - 支持 `startDate/endDate`（默认最近30天）
  - 趋势日期连续补齐
  - 漏斗阶段顺序固定
- 新增管理接口 `GET /admin/dashboard/trend-funnel`
  - 管理员 key 鉴权
  - 组织过滤参数校验
  - 日期格式与范围校验
- 在 `src/index.ts` 接线 `dashboardTrendFunnelService`

## 测试
- 新增测试：
  - `tests/metrics/dashboard-trend-funnel.test.ts`
  - `tests/metrics/admin-trend-funnel.test.ts`
- 全量通过：
  - `npm test`（67/67）
  - `npm run check`
  - `npm run build`

Closes #11
