### PR TITLE
feat: 新增学生首次登录校验接口与门禁

### DIFF
--- a/drizzle/0007_first_login_verification.sql
+++ b/drizzle/0007_first_login_verification.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `students` ADD `credential_no` varchar(32);
+ALTER TABLE `students` ADD `first_login_verified_at` timestamp;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772382173336,
       "tag": "0006_warm_lester",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "5",
+      "when": 1772385655857,
+      "tag": "0007_first_login_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,9 +72,11 @@ export const students = mysqlTable(
       .references(() => classes.id),
     studentNo: varchar("student_no", { length: 32 }).notNull(),
     name: varchar("name", { length: 64 }).notNull(),
+    credentialNo: varchar("credential_no", { length: 32 }),
     passwordHash: varchar("password_hash", { length: 255 }),
     mustChangePassword: boolean("must_change_password").notNull().default(true),
     passwordUpdatedAt: timestamp("password_updated_at"),
+    firstLoginVerifiedAt: timestamp("first_login_verified_at"),
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ import { createResourceAuthorizationService, type ResourceType } from "./modules
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
+import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
 import { createAdminRoutes } from "./routes/admin.js";
@@ -57,7 +58,9 @@ const studentRepo = {
         id: students.id,
         studentNo: students.studentNo,
         passwordHash: students.passwordHash,
-        mustChangePassword: students.mustChangePassword
+        mustChangePassword: students.mustChangePassword,
+        credentialNo: students.credentialNo,
+        firstLoginVerifiedAt: students.firstLoginVerifiedAt
       })
       .from(students)
       .where(eq(students.studentNo, studentNo))
@@ -71,7 +74,9 @@ const studentRepo = {
         id: students.id,
         studentNo: students.studentNo,
         passwordHash: students.passwordHash,
-        mustChangePassword: students.mustChangePassword
+        mustChangePassword: students.mustChangePassword,
+        credentialNo: students.credentialNo,
+        firstLoginVerifiedAt: students.firstLoginVerifiedAt
       })
       .from(students)
       .where(eq(students.id, studentId))
@@ -104,6 +109,40 @@ const studentAuthService = createStudentAuthService({
     secret: env.JWT_SECRET,
     expiresInDays: env.JWT_EXPIRES_IN_DAYS
   })
+});
+
+const studentFirstLoginVerificationRepo = {
+  async findStudentFirstLoginReference(studentId: number) {
+    const records = await db
+      .select({
+        studentId: students.id,
+        name: students.name,
+        credentialNo: students.credentialNo,
+        schoolName: colleges.name,
+        majorName: majors.name,
+        firstLoginVerifiedAt: students.firstLoginVerifiedAt
+      })
+      .from(students)
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+      .leftJoin(majors, eq(classes.majorId, majors.id))
+      .where(eq(students.id, studentId))
+      .limit(1);
+
+    return records[0] ?? null;
+  },
+  async markStudentFirstLoginVerified({ studentId, verifiedAt }: { studentId: number; verifiedAt: Date }) {
+    await db
+      .update(students)
+      .set({
+        firstLoginVerifiedAt: verifiedAt
+      })
+      .where(eq(students.id, studentId));
+  }
+};
+
+const studentFirstLoginVerificationService = createStudentFirstLoginVerificationService({
+  studentFirstLoginVerificationRepo: studentFirstLoginVerificationRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -679,7 +718,14 @@ app.get("/", (c) =>
 );
 
 app.route("/", healthRoutes);
-app.route("/auth", createAuthRoutes({ studentAuthService, requireStudentAuth }));
+app.route(
+  "/auth",
+  createAuthRoutes({
+    studentAuthService,
+    studentFirstLoginVerificationService,
+    requireStudentAuth
+  })
+);
 app.route(
   "/admin",
   createAdminRoutes({

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -18,9 +18,11 @@ export interface CreateStudentAuthMiddlewareInput {
   tokenVerifier: StudentTokenVerifier;
   studentRepo: Pick<StudentAuthRepository, "findStudentById">;
   changePasswordPath?: string;
+  firstLoginVerifyPath?: string;
 }
 
 const DEFAULT_CHANGE_PASSWORD_PATH = "/auth/student/change-password";
+const DEFAULT_FIRST_LOGIN_VERIFY_PATH = "/auth/student/first-login-verify";
 const BEARER_TOKEN_PATTERN = /^bearer\s+(\S+)\s*$/i;
 
 const parseBearerToken = (authorizationHeader: string | undefined): string | null => {
@@ -40,7 +42,8 @@ const parseBearerToken = (authorizationHeader: string | undefined): string | nul
 export const createStudentAuthMiddleware = ({
   tokenVerifier,
   studentRepo,
-  changePasswordPath = DEFAULT_CHANGE_PASSWORD_PATH
+  changePasswordPath = DEFAULT_CHANGE_PASSWORD_PATH,
+  firstLoginVerifyPath = DEFAULT_FIRST_LOGIN_VERIFY_PATH
 }: CreateStudentAuthMiddlewareInput): MiddlewareHandler => {
   return async (c, next) => {
     const token = parseBearerToken(c.req.header("authorization"));
@@ -69,6 +72,14 @@ export const createStudentAuthMiddleware = ({
 
     if (student.mustChangePassword && c.req.path !== changePasswordPath) {
       return c.json({ message: "password change required" }, 403);
+    }
+
+    if (
+      student.firstLoginVerifiedAt === null &&
+      c.req.path !== changePasswordPath &&
+      c.req.path !== firstLoginVerifyPath
+    ) {
+      return c.json({ message: "first login verification required" }, 403);
     }
 
     await next();

--- a/src/modules/auth/first-login-verification.ts
+++ b/src/modules/auth/first-login-verification.ts
@@ -1,0 +1,121 @@
+export interface StudentFirstLoginReferenceRecord {
+  studentId: number;
+  name: string;
+  credentialNo: string | null;
+  schoolName: string;
+  majorName: string | null;
+  firstLoginVerifiedAt: Date | null;
+}
+
+export interface MarkStudentFirstLoginVerifiedInput {
+  studentId: number;
+  verifiedAt: Date;
+}
+
+export interface StudentFirstLoginVerificationRepository {
+  findStudentFirstLoginReference(studentId: number): Promise<StudentFirstLoginReferenceRecord | null>;
+  markStudentFirstLoginVerified(input: MarkStudentFirstLoginVerifiedInput): Promise<void>;
+}
+
+export interface VerifyStudentFirstLoginInput {
+  studentId: number;
+  name: string;
+  credentialNo: string;
+  schoolName: string;
+  majorName: string;
+}
+
+export interface VerifyStudentFirstLoginResult {
+  verified: true;
+  verifiedAt: string;
+}
+
+export interface StudentFirstLoginVerificationService {
+  verifyStudentFirstLogin(input: VerifyStudentFirstLoginInput): Promise<VerifyStudentFirstLoginResult>;
+}
+
+export interface CreateStudentFirstLoginVerificationServiceInput {
+  studentFirstLoginVerificationRepo: StudentFirstLoginVerificationRepository;
+  nowProvider?: () => Date;
+}
+
+export class StudentFirstLoginVerificationNotFoundError extends Error {
+  constructor() {
+    super("student not found");
+    this.name = "StudentFirstLoginVerificationNotFoundError";
+  }
+}
+
+export class StudentFirstLoginVerificationMismatchError extends Error {
+  reasons: string[];
+
+  constructor(reasons: string[]) {
+    super("first login verification failed");
+    this.name = "StudentFirstLoginVerificationMismatchError";
+    this.reasons = reasons;
+  }
+}
+
+const normalize = (rawValue: string): string => rawValue.trim();
+
+export const createStudentFirstLoginVerificationService = ({
+  studentFirstLoginVerificationRepo,
+  nowProvider = () => new Date()
+}: CreateStudentFirstLoginVerificationServiceInput): StudentFirstLoginVerificationService => {
+  return {
+    async verifyStudentFirstLogin({
+      studentId,
+      name,
+      credentialNo,
+      schoolName,
+      majorName
+    }: VerifyStudentFirstLoginInput): Promise<VerifyStudentFirstLoginResult> {
+      const reference = await studentFirstLoginVerificationRepo.findStudentFirstLoginReference(studentId);
+
+      if (!reference) {
+        throw new StudentFirstLoginVerificationNotFoundError();
+      }
+
+      if (reference.firstLoginVerifiedAt) {
+        return {
+          verified: true,
+          verifiedAt: reference.firstLoginVerifiedAt.toISOString()
+        };
+      }
+
+      const reasons: string[] = [];
+
+      if (normalize(name) !== normalize(reference.name)) {
+        reasons.push("姓名不匹配");
+      }
+
+      if (!reference.credentialNo || normalize(credentialNo) !== normalize(reference.credentialNo)) {
+        reasons.push("证件号不匹配");
+      }
+
+      if (normalize(schoolName) !== normalize(reference.schoolName)) {
+        reasons.push("院校信息不匹配");
+      }
+
+      if (!reference.majorName || normalize(majorName) !== normalize(reference.majorName)) {
+        reasons.push("专业信息不匹配");
+      }
+
+      if (reasons.length > 0) {
+        throw new StudentFirstLoginVerificationMismatchError(reasons);
+      }
+
+      const verifiedAt = nowProvider();
+
+      await studentFirstLoginVerificationRepo.markStudentFirstLoginVerified({
+        studentId,
+        verifiedAt
+      });
+
+      return {
+        verified: true,
+        verifiedAt: verifiedAt.toISOString()
+      };
+    }
+  };
+};

--- a/src/modules/auth/service.ts
+++ b/src/modules/auth/service.ts
@@ -6,6 +6,8 @@ export interface StudentAuthRecord {
   studentNo: string;
   passwordHash: string | null;
   mustChangePassword: boolean;
+  credentialNo?: string | null;
+  firstLoginVerifiedAt?: Date | null;
 }
 
 export interface StudentPasswordUpdateInput {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -5,6 +5,11 @@ import {
   StudentLoginUnauthorizedError,
   type StudentAuthService
 } from "../modules/auth/service.js";
+import {
+  StudentFirstLoginVerificationMismatchError,
+  StudentFirstLoginVerificationNotFoundError,
+  type StudentFirstLoginVerificationService
+} from "../modules/auth/first-login-verification.js";
 
 interface StudentLoginRequestBody {
   studentNo: string;
@@ -16,8 +21,19 @@ interface StudentChangePasswordRequestBody {
   newPassword: string;
 }
 
+interface StudentFirstLoginVerificationRequestBody {
+  name: string;
+  credentialNo: string;
+  schoolName: string;
+  majorName: string;
+}
+
 export interface AuthRouteDependencies {
   studentAuthService: StudentAuthService;
+  studentFirstLoginVerificationService?: Pick<
+    StudentFirstLoginVerificationService,
+    "verifyStudentFirstLogin"
+  >;
   requireStudentAuth?: MiddlewareHandler;
 }
 
@@ -57,8 +73,42 @@ const isValidChangePasswordBody = (body: unknown): body is StudentChangePassword
   );
 };
 
+const isValidFirstLoginVerificationBody = (
+  body: unknown
+): body is StudentFirstLoginVerificationRequestBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const name = (body as { name?: unknown }).name;
+  const credentialNo = (body as { credentialNo?: unknown }).credentialNo;
+  const schoolName = (body as { schoolName?: unknown }).schoolName;
+  const majorName = (body as { majorName?: unknown }).majorName;
+
+  return (
+    typeof name === "string" &&
+    name.trim().length > 0 &&
+    typeof credentialNo === "string" &&
+    credentialNo.trim().length > 0 &&
+    typeof schoolName === "string" &&
+    schoolName.trim().length > 0 &&
+    typeof majorName === "string" &&
+    majorName.trim().length > 0
+  );
+};
+
+const defaultStudentFirstLoginVerificationService: Pick<
+  StudentFirstLoginVerificationService,
+  "verifyStudentFirstLogin"
+> = {
+  async verifyStudentFirstLogin() {
+    throw new Error("studentFirstLoginVerificationService is not configured");
+  }
+};
+
 export const createAuthRoutes = ({
   studentAuthService,
+  studentFirstLoginVerificationService = defaultStudentFirstLoginVerificationService,
   requireStudentAuth = passThroughAuthMiddleware
 }: AuthRouteDependencies) => {
   const auth = new Hono();
@@ -124,6 +174,53 @@ export const createAuthRoutes = ({
 
       if (error instanceof InvalidNewPasswordError) {
         return c.json({ message: error.message }, 400);
+      }
+
+      throw error;
+    }
+  });
+
+  auth.post("/student/first-login-verify", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    let body: unknown;
+
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidFirstLoginVerificationBody(body)) {
+      return c.json({ message: "name/credentialNo/schoolName/majorName is required" }, 400);
+    }
+
+    try {
+      const result = await studentFirstLoginVerificationService.verifyStudentFirstLogin({
+        studentId: studentAuth.studentId,
+        name: body.name.trim(),
+        credentialNo: body.credentialNo.trim(),
+        schoolName: body.schoolName.trim(),
+        majorName: body.majorName.trim()
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof StudentFirstLoginVerificationNotFoundError) {
+        return c.json({ message: "student not found" }, 404);
+      }
+
+      if (error instanceof StudentFirstLoginVerificationMismatchError) {
+        return c.json(
+          {
+            message: "first login verification failed",
+            reasons: error.reasons
+          },
+          422
+        );
       }
 
       throw error;

--- a/tests/auth/first-login-verification.test.ts
+++ b/tests/auth/first-login-verification.test.ts
@@ -1,0 +1,307 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { File } from "node:buffer";
+import { Hono } from "hono";
+import { createAuthRoutes } from "../../src/routes/auth.ts";
+import {
+  createStudentFirstLoginVerificationService,
+  StudentFirstLoginVerificationMismatchError,
+  type StudentFirstLoginVerificationRepository
+} from "../../src/modules/auth/first-login-verification.ts";
+import { createStudentAuthMiddleware } from "../../src/middleware/auth.ts";
+import { createJwtTokenSigner, createJwtTokenVerifier } from "../../src/modules/auth/token.ts";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+
+const jwtSecret = "b".repeat(32);
+
+const signToken = (studentId: number, studentNo: string): string => {
+  return createJwtTokenSigner({
+    secret: jwtSecret,
+    expiresInDays: 7
+  }).signStudentToken({ studentId, studentNo });
+};
+
+test("first-login verification service should throw readable mismatch reasons", async () => {
+  const repository: StudentFirstLoginVerificationRepository = {
+    async findStudentFirstLoginReference() {
+      return {
+        studentId: 1,
+        name: "张三",
+        credentialNo: "440101199901011234",
+        schoolName: "华南理工大学",
+        majorName: "软件工程",
+        firstLoginVerifiedAt: null
+      };
+    },
+    async markStudentFirstLoginVerified() {
+      return;
+    }
+  };
+
+  const service = createStudentFirstLoginVerificationService({
+    studentFirstLoginVerificationRepo: repository,
+    nowProvider: () => new Date("2026-03-01T00:00:00Z")
+  });
+
+  await assert.rejects(
+    async () => {
+      await service.verifyStudentFirstLogin({
+        studentId: 1,
+        name: "李四",
+        credentialNo: "440101199901011111",
+        schoolName: "华南理工大学",
+        majorName: "计算机科学"
+      });
+    },
+    (error) => {
+      assert.ok(error instanceof StudentFirstLoginVerificationMismatchError);
+      assert.deepEqual(error.reasons, ["姓名不匹配", "证件号不匹配", "专业信息不匹配"]);
+      return true;
+    }
+  );
+});
+
+test("POST /auth/student/first-login-verify should return 400 when body invalid", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      studentFirstLoginVerificationService: {
+        async verifyStudentFirstLogin() {
+          return {
+            verified: true,
+            verifiedAt: "2026-03-01T00:00:00.000Z"
+          };
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/first-login-verify", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${signToken(1, "S20260001")}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      name: "张三"
+    })
+  });
+
+  assert.equal(response.status, 400);
+});
+
+test("POST /auth/student/first-login-verify should return readable mismatch reasons", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      studentFirstLoginVerificationService: {
+        async verifyStudentFirstLogin() {
+          throw new StudentFirstLoginVerificationMismatchError([
+            "姓名不匹配",
+            "证件号不匹配"
+          ]);
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/first-login-verify", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${signToken(1, "S20260001")}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      name: "张三",
+      credentialNo: "440101199901011234",
+      schoolName: "华南理工大学",
+      majorName: "软件工程"
+    })
+  });
+
+  assert.equal(response.status, 422);
+  assert.deepEqual(await response.json(), {
+    message: "first login verification failed",
+    reasons: ["姓名不匹配", "证件号不匹配"]
+  });
+});
+
+test("POST /auth/student/first-login-verify should persist verification state", async () => {
+  const calls: Array<{ studentId: number }> = [];
+
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      studentFirstLoginVerificationService: {
+        async verifyStudentFirstLogin(input) {
+          calls.push({ studentId: input.studentId });
+          return {
+            verified: true,
+            verifiedAt: "2026-03-01T00:00:00.000Z"
+          };
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/first-login-verify", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${signToken(1, "S20260001")}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      name: "张三",
+      credentialNo: "440101199901011234",
+      schoolName: "华南理工大学",
+      majorName: "软件工程"
+    })
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    verified: true,
+    verifiedAt: "2026-03-01T00:00:00.000Z"
+  });
+  assert.deepEqual(calls, [{ studentId: 1 }]);
+});
+
+test("student core route should return 403 before first-login verification", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth,
+      certificateUploadService: {
+        async uploadCertificate() {
+          return {
+            fileId: "cert_xxx"
+          };
+        }
+      }
+    })
+  );
+
+  const formData = new FormData();
+  formData.append("file", new File([Buffer.from("ok")], "proof.jpg", { type: "image/jpeg" }));
+
+  const response = await app.request("/student/certificates/upload", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${signToken(1, "S20260001")}`
+    },
+    body: formData
+  });
+
+  assert.equal(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    message: "first login verification required"
+  });
+});

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -130,3 +130,15 @@ test("0006 migration file should include major dimension and report direction up
   assert.match(migrationSql, /ADD\s+`major_id`\s+int/i);
   assert.match(migrationSql, /ADD\s+`direction`/i);
 });
+
+test("0007 migration file should include student first-login verification fields", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0007 = migrationFiles.find((fileName) => /^0007_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0007, "expected a 0007 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0007), "utf8");
+
+  assert.match(migrationSql, /ADD\s+`credential_no`\s+varchar\(32\)/i);
+  assert.match(migrationSql, /ADD\s+`first_login_verified_at`\s+timestamp/i);
+});

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -39,6 +39,8 @@ test("students should include password security fields", () => {
   assert.equal(students.passwordHash.name, "password_hash");
   assert.equal(students.mustChangePassword.name, "must_change_password");
   assert.equal(students.passwordUpdatedAt.name, "password_updated_at");
+  assert.equal(students.credentialNo.name, "credential_no");
+  assert.equal(students.firstLoginVerifiedAt.name, "first_login_verified_at");
   assert.equal(students.mustChangePassword.notNull, true);
   assert.equal(students.mustChangePassword.hasDefault, true);
   assert.equal(students.passwordHash.notNull, false);


### PR DESCRIPTION
## 变更说明
完成 S01「学生首次登录校验接口（姓名+证件+专业/院校）」：

- 新增首次登录校验服务 `src/modules/auth/first-login-verification.ts`
  - 四要素校验：姓名、证件号、院校、专业
  - 校验失败返回可读错误原因（reasons）
  - 校验通过后持久化状态
- 新增接口 `POST /auth/student/first-login-verify`
  - 鉴权 + 请求体校验
  - 错误处理：400 / 404 / 422
- 在 `src/middleware/auth.ts` 增加首次登录校验门禁
  - 未通过首次登录校验前，阻断学生核心受保护接口访问（403）
- 数据与迁移
  - `students` 新增 `credential_no`、`first_login_verified_at`
  - 新增迁移文件 `drizzle/0007_first_login_verification.sql`

## 测试
- 新增：`tests/auth/first-login-verification.test.ts`
- 更新：
  - `tests/db/schema.test.ts`
  - `tests/db/migrations.test.ts`
- 全量通过：
  - `npm test`（81/81）
  - `npm run check`
  - `npm run build`

Closes #13
