### PR TITLE
feat: 实现招生数据自动拉取接口与只读策略

### DIFF
--- a/drizzle/0008_enrollment_profiles.sql
+++ b/drizzle/0008_enrollment_profiles.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `enrollment_profiles` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `student_no` varchar(32) NOT NULL,
+  `name` varchar(64),
+  `school_name` varchar(128),
+  `major_name` varchar(128),
+  `score` int,
+  `admission_year` int,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `enrollment_profiles_id` PRIMARY KEY(`id`),
+  CONSTRAINT `enrollment_profiles_student_no_unique` UNIQUE(`student_no`)
+);
+--> statement-breakpoint
+CREATE INDEX `enrollment_profiles_student_no_idx` ON `enrollment_profiles` (`student_no`);
+--> statement-breakpoint
+CREATE INDEX `enrollment_profiles_admission_year_idx` ON `enrollment_profiles` (`admission_year`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1772385655857,
       "tag": "0007_first_login_verification",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1772386204941,
+      "tag": "0008_enrollment_profiles",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -85,6 +85,26 @@ export const students = mysqlTable(
   })
 );
 
+export const enrollmentProfiles = mysqlTable(
+  "enrollment_profiles",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    studentNo: varchar("student_no", { length: 32 }).notNull(),
+    name: varchar("name", { length: 64 }),
+    schoolName: varchar("school_name", { length: 128 }),
+    majorName: varchar("major_name", { length: 128 }),
+    score: int("score"),
+    admissionYear: int("admission_year"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull()
+  },
+  (table) => ({
+    studentNoUnique: uniqueIndex("enrollment_profiles_student_no_unique").on(table.studentNo),
+    studentNoIdx: index("enrollment_profiles_student_no_idx").on(table.studentNo),
+    admissionYearIdx: index("enrollment_profiles_admission_year_idx").on(table.admissionYear)
+  })
+);
+
 export const reports = mysqlTable(
   "reports",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   classes,
   certificates,
   colleges,
+  enrollmentProfiles,
   majors,
   profiles,
   reports,
@@ -43,6 +44,7 @@ import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/pas
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
+import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
 import { createAdminRoutes } from "./routes/admin.js";
@@ -143,6 +145,29 @@ const studentFirstLoginVerificationRepo = {
 
 const studentFirstLoginVerificationService = createStudentFirstLoginVerificationService({
   studentFirstLoginVerificationRepo: studentFirstLoginVerificationRepo
+});
+
+const enrollmentProfileRepo = {
+  async findEnrollmentProfileByStudentNo(studentNo: string) {
+    const records = await db
+      .select({
+        studentNo: enrollmentProfiles.studentNo,
+        name: enrollmentProfiles.name,
+        schoolName: enrollmentProfiles.schoolName,
+        majorName: enrollmentProfiles.majorName,
+        score: enrollmentProfiles.score,
+        admissionYear: enrollmentProfiles.admissionYear
+      })
+      .from(enrollmentProfiles)
+      .where(eq(enrollmentProfiles.studentNo, studentNo))
+      .limit(1);
+
+    return records[0] ?? null;
+  }
+};
+
+const enrollmentProfileService = createEnrollmentProfileService({
+  enrollmentProfileRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -723,6 +748,7 @@ app.route(
   createAuthRoutes({
     studentAuthService,
     studentFirstLoginVerificationService,
+    enrollmentProfileService,
     requireStudentAuth
   })
 );

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -19,10 +19,12 @@ export interface CreateStudentAuthMiddlewareInput {
   studentRepo: Pick<StudentAuthRepository, "findStudentById">;
   changePasswordPath?: string;
   firstLoginVerifyPath?: string;
+  enrollmentProfilePath?: string;
 }
 
 const DEFAULT_CHANGE_PASSWORD_PATH = "/auth/student/change-password";
 const DEFAULT_FIRST_LOGIN_VERIFY_PATH = "/auth/student/first-login-verify";
+const DEFAULT_ENROLLMENT_PROFILE_PATH = "/auth/student/enrollment-profile";
 const BEARER_TOKEN_PATTERN = /^bearer\s+(\S+)\s*$/i;
 
 const parseBearerToken = (authorizationHeader: string | undefined): string | null => {
@@ -43,7 +45,8 @@ export const createStudentAuthMiddleware = ({
   tokenVerifier,
   studentRepo,
   changePasswordPath = DEFAULT_CHANGE_PASSWORD_PATH,
-  firstLoginVerifyPath = DEFAULT_FIRST_LOGIN_VERIFY_PATH
+  firstLoginVerifyPath = DEFAULT_FIRST_LOGIN_VERIFY_PATH,
+  enrollmentProfilePath = DEFAULT_ENROLLMENT_PROFILE_PATH
 }: CreateStudentAuthMiddlewareInput): MiddlewareHandler => {
   return async (c, next) => {
     const token = parseBearerToken(c.req.header("authorization"));
@@ -77,7 +80,8 @@ export const createStudentAuthMiddleware = ({
     if (
       student.firstLoginVerifiedAt === null &&
       c.req.path !== changePasswordPath &&
-      c.req.path !== firstLoginVerifyPath
+      c.req.path !== firstLoginVerifyPath &&
+      c.req.path !== enrollmentProfilePath
     ) {
       return c.json({ message: "first login verification required" }, 403);
     }

--- a/src/modules/enrollment/profile.ts
+++ b/src/modules/enrollment/profile.ts
@@ -1,0 +1,103 @@
+export interface EnrollmentProfileRecord {
+  studentNo: string;
+  name: string | null;
+  schoolName: string | null;
+  majorName: string | null;
+  score: number | null;
+  admissionYear: number | null;
+}
+
+export interface EnrollmentProfileRepository {
+  findEnrollmentProfileByStudentNo(studentNo: string): Promise<EnrollmentProfileRecord | null>;
+}
+
+export interface GetEnrollmentProfileInput {
+  studentNo: string;
+}
+
+export type EnrollmentProfileField =
+  | "name"
+  | "schoolName"
+  | "majorName"
+  | "score"
+  | "admissionYear";
+
+export type EnrollmentProfileDataStatus = "complete" | "partial_missing" | "missing";
+
+export interface EnrollmentProfileResult {
+  studentNo: string;
+  profile: {
+    name: string | null;
+    schoolName: string | null;
+    majorName: string | null;
+    score: number | null;
+    admissionYear: number | null;
+  };
+  dataStatus: EnrollmentProfileDataStatus;
+  missingFields: EnrollmentProfileField[];
+  readonly: true;
+}
+
+export interface EnrollmentProfileService {
+  getEnrollmentProfile(input: GetEnrollmentProfileInput): Promise<EnrollmentProfileResult>;
+}
+
+export interface CreateEnrollmentProfileServiceInput {
+  enrollmentProfileRepo: EnrollmentProfileRepository;
+}
+
+const ENROLLMENT_FIELDS: EnrollmentProfileField[] = [
+  "name",
+  "schoolName",
+  "majorName",
+  "score",
+  "admissionYear"
+];
+
+const resolveMissingFields = (
+  profile: EnrollmentProfileResult["profile"]
+): EnrollmentProfileField[] => {
+  return ENROLLMENT_FIELDS.filter((field) => profile[field] === null);
+};
+
+const resolveDataStatus = (
+  missingFields: EnrollmentProfileField[]
+): EnrollmentProfileDataStatus => {
+  if (missingFields.length === 0) {
+    return "complete";
+  }
+
+  if (missingFields.length === ENROLLMENT_FIELDS.length) {
+    return "missing";
+  }
+
+  return "partial_missing";
+};
+
+export const createEnrollmentProfileService = ({
+  enrollmentProfileRepo
+}: CreateEnrollmentProfileServiceInput): EnrollmentProfileService => {
+  return {
+    async getEnrollmentProfile({ studentNo }: GetEnrollmentProfileInput): Promise<EnrollmentProfileResult> {
+      const rawProfile = await enrollmentProfileRepo.findEnrollmentProfileByStudentNo(studentNo);
+
+      const profile = {
+        name: rawProfile?.name ?? null,
+        schoolName: rawProfile?.schoolName ?? null,
+        majorName: rawProfile?.majorName ?? null,
+        score: rawProfile?.score ?? null,
+        admissionYear: rawProfile?.admissionYear ?? null
+      };
+
+      const missingFields = resolveMissingFields(profile);
+
+      return {
+        studentNo,
+        profile,
+        dataStatus: resolveDataStatus(missingFields),
+        missingFields,
+        readonly: true
+      };
+    }
+  };
+};

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -10,6 +10,7 @@ import {
   StudentFirstLoginVerificationNotFoundError,
   type StudentFirstLoginVerificationService
 } from "../modules/auth/first-login-verification.js";
+import type { EnrollmentProfileService } from "../modules/enrollment/profile.js";
 
 interface StudentLoginRequestBody {
   studentNo: string;
@@ -34,6 +35,7 @@ export interface AuthRouteDependencies {
     StudentFirstLoginVerificationService,
     "verifyStudentFirstLogin"
   >;
+  enrollmentProfileService?: Pick<EnrollmentProfileService, "getEnrollmentProfile">;
   requireStudentAuth?: MiddlewareHandler;
 }
 
@@ -106,9 +108,16 @@ const defaultStudentFirstLoginVerificationService: Pick<
   }
 };
 
+const defaultEnrollmentProfileService: Pick<EnrollmentProfileService, "getEnrollmentProfile"> = {
+  async getEnrollmentProfile() {
+    throw new Error("enrollmentProfileService is not configured");
+  }
+};
+
 export const createAuthRoutes = ({
   studentAuthService,
   studentFirstLoginVerificationService = defaultStudentFirstLoginVerificationService,
+  enrollmentProfileService = defaultEnrollmentProfileService,
   requireStudentAuth = passThroughAuthMiddleware
 }: AuthRouteDependencies) => {
   const auth = new Hono();
@@ -225,6 +234,20 @@ export const createAuthRoutes = ({
 
       throw error;
     }
+  });
+
+  auth.get("/student/enrollment-profile", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const result = await enrollmentProfileService.getEnrollmentProfile({
+      studentNo: studentAuth.studentNo
+    });
+
+    return c.json(result, 200);
   });
 
   return auth;

--- a/tests/auth/enrollment-profile.test.ts
+++ b/tests/auth/enrollment-profile.test.ts
@@ -1,0 +1,267 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAuthRoutes } from "../../src/routes/auth.ts";
+import {
+  createEnrollmentProfileService,
+  type EnrollmentProfileRepository
+} from "../../src/modules/enrollment/profile.ts";
+import { createStudentAuthMiddleware } from "../../src/middleware/auth.ts";
+import { createJwtTokenSigner, createJwtTokenVerifier } from "../../src/modules/auth/token.ts";
+
+const jwtSecret = "c".repeat(32);
+
+const signToken = ({ studentId, studentNo }: { studentId: number; studentNo: string }): string => {
+  return createJwtTokenSigner({
+    secret: jwtSecret,
+    expiresInDays: 7
+  }).signStudentToken({ studentId, studentNo });
+};
+
+test("enrollment profile service should return complete status when all fields exist", async () => {
+  const repo: EnrollmentProfileRepository = {
+    async findEnrollmentProfileByStudentNo() {
+      return {
+        studentNo: "S20260001",
+        name: "张三",
+        schoolName: "华南理工大学",
+        majorName: "软件工程",
+        score: 612,
+        admissionYear: 2022
+      };
+    }
+  };
+
+  const service = createEnrollmentProfileService({
+    enrollmentProfileRepo: repo
+  });
+
+  const result = await service.getEnrollmentProfile({
+    studentNo: "S20260001"
+  });
+
+  assert.equal(result.dataStatus, "complete");
+  assert.deepEqual(result.missingFields, []);
+  assert.equal(result.readonly, true);
+  assert.equal(result.profile.score, 612);
+});
+
+test("enrollment profile service should return missing status when no profile found", async () => {
+  const repo: EnrollmentProfileRepository = {
+    async findEnrollmentProfileByStudentNo() {
+      return null;
+    }
+  };
+
+  const service = createEnrollmentProfileService({
+    enrollmentProfileRepo: repo
+  });
+
+  const result = await service.getEnrollmentProfile({
+    studentNo: "S20260001"
+  });
+
+  assert.equal(result.dataStatus, "missing");
+  assert.ok(result.missingFields.includes("name"));
+  assert.ok(result.missingFields.includes("score"));
+});
+
+test("GET /auth/student/enrollment-profile should return 401 when token missing", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      enrollmentProfileService: {
+        async getEnrollmentProfile() {
+          return {
+            studentNo: "S20260001",
+            profile: {
+              name: "张三",
+              schoolName: "华南理工大学",
+              majorName: "软件工程",
+              score: 612,
+              admissionYear: 2022
+            },
+            dataStatus: "complete" as const,
+            missingFields: [],
+            readonly: true
+          };
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/enrollment-profile");
+  assert.equal(response.status, 401);
+});
+
+test("GET /auth/student/enrollment-profile should return profile after login (even before first-login verify)", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: null
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      enrollmentProfileService: {
+        async getEnrollmentProfile() {
+          return {
+            studentNo: "S20260001",
+            profile: {
+              name: "张三",
+              schoolName: "华南理工大学",
+              majorName: "软件工程",
+              score: null,
+              admissionYear: 2022
+            },
+            dataStatus: "partial_missing" as const,
+            missingFields: ["score"],
+            readonly: true
+          };
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/enrollment-profile", {
+    headers: {
+      authorization: `Bearer ${signToken({ studentId: 1, studentNo: "S20260001" })}`
+    }
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    studentNo: "S20260001",
+    profile: {
+      name: "张三",
+      schoolName: "华南理工大学",
+      majorName: "软件工程",
+      score: null,
+      admissionYear: 2022
+    },
+    dataStatus: "partial_missing",
+    missingFields: ["score"],
+    readonly: true
+  });
+});
+
+test("student should not have API to overwrite enrollment source fields", async () => {
+  const studentRepo = {
+    async findStudentById() {
+      return {
+        id: 1,
+        studentNo: "S20260001",
+        passwordHash: "hash",
+        mustChangePassword: false,
+        firstLoginVerifiedAt: new Date("2026-03-01T00:00:00Z")
+      };
+    }
+  };
+
+  const requireStudentAuth = createStudentAuthMiddleware({
+    tokenVerifier: createJwtTokenVerifier({ secret: jwtSecret }),
+    studentRepo
+  });
+
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          throw new Error("not implemented");
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      enrollmentProfileService: {
+        async getEnrollmentProfile() {
+          return {
+            studentNo: "S20260001",
+            profile: {
+              name: "张三",
+              schoolName: "华南理工大学",
+              majorName: "软件工程",
+              score: 612,
+              admissionYear: 2022
+            },
+            dataStatus: "complete" as const,
+            missingFields: [],
+            readonly: true
+          };
+        }
+      },
+      requireStudentAuth
+    })
+  );
+
+  const response = await app.request("/auth/student/enrollment-profile", {
+    method: "PUT",
+    headers: {
+      authorization: `Bearer ${signToken({ studentId: 1, studentNo: "S20260001" })}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ score: 100 })
+  });
+
+  assert.equal(response.status, 404);
+});

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 7, "journal should contain at least 7 entries");
+  assert.ok(entries.length >= 8, "journal should contain at least 8 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -141,4 +141,18 @@ test("0007 migration file should include student first-login verification fields
 
   assert.match(migrationSql, /ADD\s+`credential_no`\s+varchar\(32\)/i);
   assert.match(migrationSql, /ADD\s+`first_login_verified_at`\s+timestamp/i);
+});
+
+test("0008 migration file should include enrollment_profiles source table", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0008 = migrationFiles.find((fileName) => /^0008_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0008, "expected a 0008 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0008), "utf8");
+
+  assert.match(migrationSql, /CREATE TABLE\s+`enrollment_profiles`/i);
+  assert.match(migrationSql, /`student_no`\s+varchar\(32\)\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /`score`\s+int/i);
+  assert.match(migrationSql, /`admission_year`\s+int/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -8,6 +8,7 @@ import {
   classes,
   certificates,
   colleges,
+  enrollmentProfiles,
   majors,
   profiles,
   reports,
@@ -90,4 +91,11 @@ test("schema should include major dimension and report direction fields", () => 
   assert.equal(classes.majorId.name, "major_id");
   assert.equal(colleges.schoolId.name, "school_id");
   assert.equal(reports.direction.name, "direction");
+});
+
+test("schema should include enrollment_profiles read-only source table", () => {
+  assert.equal(enrollmentProfiles[Symbol.for("drizzle:Name")], "enrollment_profiles");
+  assert.equal(enrollmentProfiles.studentNo.name, "student_no");
+  assert.equal(enrollmentProfiles.score.name, "score");
+  assert.equal(enrollmentProfiles.admissionYear.name, "admission_year");
 });


### PR DESCRIPTION
## 变更说明
- 新增 `enrollment_profiles` 数据表与 Drizzle schema 映射
- 新增 `GET /auth/student/enrollment-profile` 接口（登录后可查询）
- 返回 `dataStatus` / `missingFields` 明确字段缺失状态
- 返回 `readonly: true`，并保持无学生端覆盖接口
- 放开首登校验门禁，允许未完成首登校验的学生读取招生画像
- 补充服务层、路由层与迁移/Schema 测试

## 验证
- `pnpm test`（88/88 通过）

Closes #14