### PR TITLE
feat: 实现50题Likert测评题库与提交覆盖策略

### DIFF
--- a/drizzle/0009_assessment_submissions.sql
+++ b/drizzle/0009_assessment_submissions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `assessment_submissions` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `student_id` int NOT NULL,
+  `question_set_version` varchar(32) NOT NULL DEFAULT 'v1',
+  `answers_json` text NOT NULL,
+  `answer_count` int NOT NULL,
+  `submitted_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `assessment_submissions_id` PRIMARY KEY(`id`),
+  CONSTRAINT `assessment_submissions_student_id_unique` UNIQUE(`student_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `assessment_submissions` ADD CONSTRAINT `assessment_submissions_student_id_students_id_fk` FOREIGN KEY (`student_id`) REFERENCES `students`(`id`) ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX `assessment_submissions_submitted_at_idx` ON `assessment_submissions` (`submitted_at`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1772386204941,
       "tag": "0008_enrollment_profiles",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1772415578728,
+      "tag": "0009_assessment_submissions",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -4,6 +4,7 @@ import {
   int,
   mysqlEnum,
   mysqlTable,
+  text,
   timestamp,
   uniqueIndex,
   varchar
@@ -102,6 +103,25 @@ export const enrollmentProfiles = mysqlTable(
     studentNoUnique: uniqueIndex("enrollment_profiles_student_no_unique").on(table.studentNo),
     studentNoIdx: index("enrollment_profiles_student_no_idx").on(table.studentNo),
     admissionYearIdx: index("enrollment_profiles_admission_year_idx").on(table.admissionYear)
+  })
+);
+
+export const assessmentSubmissions = mysqlTable(
+  "assessment_submissions",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    studentId: int("student_id")
+      .notNull()
+      .references(() => students.id),
+    questionSetVersion: varchar("question_set_version", { length: 32 }).notNull().default("v1"),
+    answersJson: text("answers_json").notNull(),
+    answerCount: int("answer_count").notNull(),
+    submittedAt: timestamp("submitted_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull()
+  },
+  (table) => ({
+    studentIdUnique: uniqueIndex("assessment_submissions_student_id_unique").on(table.studentId),
+    submittedAtIdx: index("assessment_submissions_submitted_at_idx").on(table.submittedAt)
   })
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { env } from "./config/env.js";
 import { db } from "./db/client.js";
 import {
+  assessmentSubmissions,
   activities,
   auditLogs,
   certificateFiles,
@@ -44,6 +45,7 @@ import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/pas
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
+import { createLikertAssessmentService } from "./modules/assessment/likert.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -168,6 +170,63 @@ const enrollmentProfileRepo = {
 
 const enrollmentProfileService = createEnrollmentProfileService({
   enrollmentProfileRepo
+});
+
+const likertAssessmentSubmissionRepo = {
+  async findSubmissionByStudentId(studentId: number) {
+    const records = await db
+      .select({
+        id: assessmentSubmissions.id,
+        studentId: assessmentSubmissions.studentId,
+        answersJson: assessmentSubmissions.answersJson,
+        answerCount: assessmentSubmissions.answerCount
+      })
+      .from(assessmentSubmissions)
+      .where(eq(assessmentSubmissions.studentId, studentId))
+      .limit(1);
+
+    return records[0] ?? null;
+  },
+  async createSubmission({ studentId, answersJson, answerCount, submittedAt }: {
+    studentId: number;
+    answersJson: string;
+    answerCount: number;
+    submittedAt: Date;
+  }) {
+    const insertResult = await db
+      .insert(assessmentSubmissions)
+      .values({
+        studentId,
+        answersJson,
+        answerCount,
+        questionSetVersion: "v1",
+        submittedAt,
+        updatedAt: submittedAt
+      });
+
+    return Number(insertResult[0].insertId);
+  },
+  async updateSubmission({ id, answersJson, answerCount, submittedAt }: {
+    id: number;
+    studentId: number;
+    answersJson: string;
+    answerCount: number;
+    submittedAt: Date;
+  }) {
+    await db
+      .update(assessmentSubmissions)
+      .set({
+        answersJson,
+        answerCount,
+        submittedAt,
+        updatedAt: submittedAt
+      })
+      .where(eq(assessmentSubmissions.id, id));
+  }
+};
+
+const likertAssessmentService = createLikertAssessmentService({
+  submissionRepo: likertAssessmentSubmissionRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -766,7 +825,14 @@ app.route(
   })
 );
 app.route("/resources", createResourcesRoutes({ createResourceAuthorization }));
-app.route("/student", createStudentRoutes({ requireStudentAuth, certificateUploadService }));
+app.route(
+  "/student",
+  createStudentRoutes({
+    requireStudentAuth,
+    certificateUploadService,
+    likertAssessmentService
+  })
+);
 
 serve(
   {

--- a/src/modules/assessment/likert.ts
+++ b/src/modules/assessment/likert.ts
@@ -1,0 +1,206 @@
+export interface LikertQuestion {
+  questionId: number;
+  content: string;
+  dimension: "interest" | "ability" | "value";
+}
+
+export interface LikertQuestionSet {
+  version: "v1";
+  scaleMin: 1;
+  scaleMax: 5;
+  questions: LikertQuestion[];
+}
+
+export interface LikertAnswerInput {
+  questionId: number;
+  score: number;
+}
+
+export interface PersistLikertSubmissionInput {
+  studentId: number;
+  answersJson: string;
+  answerCount: number;
+  submittedAt: Date;
+}
+
+export interface UpdateLikertSubmissionInput extends PersistLikertSubmissionInput {
+  id: number;
+}
+
+export interface LikertSubmissionRecord {
+  id: number;
+  studentId: number;
+  answersJson: string;
+  answerCount: number;
+}
+
+export interface LikertAssessmentSubmissionRepository {
+  findSubmissionByStudentId(studentId: number): Promise<LikertSubmissionRecord | null>;
+  createSubmission(input: PersistLikertSubmissionInput): Promise<number>;
+  updateSubmission(input: UpdateLikertSubmissionInput): Promise<void>;
+}
+
+export interface SubmitLikertAnswersInput {
+  studentId: number;
+  answers: LikertAnswerInput[];
+}
+
+export interface SubmitLikertAnswersResult {
+  submissionId: number;
+  overwritten: boolean;
+  answerCount: number;
+  submittedAt: string;
+}
+
+export interface LikertAssessmentService {
+  getQuestions(): Promise<LikertQuestionSet>;
+  submitAnswers(input: SubmitLikertAnswersInput): Promise<SubmitLikertAnswersResult>;
+}
+
+export interface CreateLikertAssessmentServiceInput {
+  submissionRepo: LikertAssessmentSubmissionRepository;
+}
+
+export class InvalidLikertAnswersError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidLikertAnswersError";
+  }
+}
+
+const LIKERT_QUESTION_COUNT = 50;
+
+const LIKERT_QUESTIONS: LikertQuestion[] = [
+  { questionId: 1, content: "我会主动关注就业与升学相关信息。", dimension: "interest" },
+  { questionId: 2, content: "我愿意持续投入时间探索未来职业方向。", dimension: "interest" },
+  { questionId: 3, content: "我对参加职业体验活动有较强兴趣。", dimension: "interest" },
+  { questionId: 4, content: "我会主动向老师或学长请教职业发展问题。", dimension: "interest" },
+  { questionId: 5, content: "我愿意尝试不同领域以明确个人方向。", dimension: "interest" },
+  { questionId: 6, content: "我对专业相关岗位保持长期关注。", dimension: "interest" },
+  { questionId: 7, content: "我愿意阅读政策与行业报告了解趋势。", dimension: "interest" },
+  { questionId: 8, content: "我会主动复盘自己的学习与实践经历。", dimension: "interest" },
+  { questionId: 9, content: "我希望尽早形成清晰的生涯规划。", dimension: "interest" },
+  { questionId: 10, content: "我愿意为目标岗位持续提升竞争力。", dimension: "interest" },
+  { questionId: 11, content: "我能清楚表达自己的优势与特长。", dimension: "ability" },
+  { questionId: 12, content: "我具备将课堂知识应用到实际问题的能力。", dimension: "ability" },
+  { questionId: 13, content: "我能独立完成并按时交付学习任务。", dimension: "ability" },
+  { questionId: 14, content: "我能在团队中高效沟通并协同推进。", dimension: "ability" },
+  { questionId: 15, content: "我能快速学习新工具并用于解决问题。", dimension: "ability" },
+  { questionId: 16, content: "我在压力下仍能保持稳定执行。", dimension: "ability" },
+  { questionId: 17, content: "我具备基本的职业素养与规则意识。", dimension: "ability" },
+  { questionId: 18, content: "我能根据反馈及时调整学习与行动策略。", dimension: "ability" },
+  { questionId: 19, content: "我能持续积累可展示的项目或成果。", dimension: "ability" },
+  { questionId: 20, content: "我能对复杂任务进行拆解并制定计划。", dimension: "ability" },
+  { questionId: 21, content: "我认可长期主义对个人发展的价值。", dimension: "value" },
+  { questionId: 22, content: "我更重视岗位与个人能力匹配度。", dimension: "value" },
+  { questionId: 23, content: "我愿意在择业时兼顾社会责任。", dimension: "value" },
+  { questionId: 24, content: "我认同持续学习是职业发展的基础。", dimension: "value" },
+  { questionId: 25, content: "我愿意为长期目标接受阶段性挑战。", dimension: "value" },
+  { questionId: 26, content: "我重视职业选择中的诚信与规范。", dimension: "value" },
+  { questionId: 27, content: "我认为自我驱动比外部督促更重要。", dimension: "value" },
+  { questionId: 28, content: "我愿意通过实践服务社会与他人。", dimension: "value" },
+  { questionId: 29, content: "我会在重大选择前充分评估风险。", dimension: "value" },
+  { questionId: 30, content: "我能够平衡短期收益与长期成长。", dimension: "value" },
+  { questionId: 31, content: "我会主动制定并执行每周学习计划。", dimension: "interest" },
+  { questionId: 32, content: "我会关注目标岗位所需能力变化。", dimension: "interest" },
+  { questionId: 33, content: "我愿意主动参与校内外职业活动。", dimension: "interest" },
+  { questionId: 34, content: "我对生涯课程或讲座保持积极态度。", dimension: "interest" },
+  { questionId: 35, content: "我愿意根据兴趣拓展跨学科学习。", dimension: "interest" },
+  { questionId: 36, content: "我能独立完成简历与作品集准备。", dimension: "ability" },
+  { questionId: 37, content: "我能在公开场景清晰表达观点。", dimension: "ability" },
+  { questionId: 38, content: "我具备基础数据分析与信息检索能力。", dimension: "ability" },
+  { questionId: 39, content: "我能将抽象目标转化为可执行任务。", dimension: "ability" },
+  { questionId: 40, content: "我能在失败后快速总结并再次尝试。", dimension: "ability" },
+  { questionId: 41, content: "我认同职业发展应兼顾个人与家庭。", dimension: "value" },
+  { questionId: 42, content: "我愿意在合规前提下追求效率。", dimension: "value" },
+  { questionId: 43, content: "我重视对团队与组织的承诺。", dimension: "value" },
+  { questionId: 44, content: "我认同跨地域发展的可能性与价值。", dimension: "value" },
+  { questionId: 45, content: "我愿意在不确定环境中保持行动。", dimension: "value" },
+  { questionId: 46, content: "我会主动规划实习或项目实践路径。", dimension: "interest" },
+  { questionId: 47, content: "我愿意提前准备求职或升学关键节点。", dimension: "interest" },
+  { questionId: 48, content: "我能对外部信息进行独立判断。", dimension: "ability" },
+  { questionId: 49, content: "我能在时间冲突中合理安排优先级。", dimension: "ability" },
+  { questionId: 50, content: "我认可以终为始的长期规划方式。", dimension: "value" }
+];
+
+const validateLikertAnswers = (answers: LikertAnswerInput[]) => {
+  if (!Array.isArray(answers) || answers.length !== LIKERT_QUESTION_COUNT) {
+    throw new InvalidLikertAnswersError("answers must include exactly 50 likert items");
+  }
+
+  const questionIds = new Set<number>();
+
+  for (const item of answers) {
+    if (!Number.isInteger(item.questionId) || item.questionId < 1 || item.questionId > LIKERT_QUESTION_COUNT) {
+      throw new InvalidLikertAnswersError("questionId must be integer and between 1 and 50");
+    }
+
+    if (!Number.isInteger(item.score) || item.score < 1 || item.score > 5) {
+      throw new InvalidLikertAnswersError("score must be integer and between 1 and 5");
+    }
+
+    questionIds.add(item.questionId);
+  }
+
+  if (questionIds.size !== LIKERT_QUESTION_COUNT) {
+    throw new InvalidLikertAnswersError("questionId must cover 1-50 without duplicates");
+  }
+};
+
+const normalizeAnswers = (answers: LikertAnswerInput[]): LikertAnswerInput[] => {
+  return [...answers].sort((left, right) => left.questionId - right.questionId);
+};
+
+export const createLikertAssessmentService = ({
+  submissionRepo
+}: CreateLikertAssessmentServiceInput): LikertAssessmentService => {
+  return {
+    async getQuestions(): Promise<LikertQuestionSet> {
+      return {
+        version: "v1",
+        scaleMin: 1,
+        scaleMax: 5,
+        questions: LIKERT_QUESTIONS
+      };
+    },
+    async submitAnswers({ studentId, answers }: SubmitLikertAnswersInput): Promise<SubmitLikertAnswersResult> {
+      validateLikertAnswers(answers);
+
+      const normalizedAnswers = normalizeAnswers(answers);
+      const answersJson = JSON.stringify(normalizedAnswers);
+      const submittedAt = new Date();
+      const existing = await submissionRepo.findSubmissionByStudentId(studentId);
+
+      if (existing) {
+        await submissionRepo.updateSubmission({
+          id: existing.id,
+          studentId,
+          answersJson,
+          answerCount: LIKERT_QUESTION_COUNT,
+          submittedAt
+        });
+
+        return {
+          submissionId: existing.id,
+          overwritten: true,
+          answerCount: LIKERT_QUESTION_COUNT,
+          submittedAt: submittedAt.toISOString()
+        };
+      }
+
+      const createdId = await submissionRepo.createSubmission({
+        studentId,
+        answersJson,
+        answerCount: LIKERT_QUESTION_COUNT,
+        submittedAt
+      });
+
+      return {
+        submissionId: createdId,
+        overwritten: false,
+        answerCount: LIKERT_QUESTION_COUNT,
+        submittedAt: submittedAt.toISOString()
+      };
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -6,10 +6,15 @@ import {
   type CertificateUploadService,
   type UploadedFile
 } from "../modules/upload/certificate-upload.js";
+import {
+  InvalidLikertAnswersError,
+  type LikertAssessmentService
+} from "../modules/assessment/likert.js";
 
 export interface StudentRouteDependencies {
   requireStudentAuth: MiddlewareHandler;
   certificateUploadService: CertificateUploadService;
+  likertAssessmentService?: Pick<LikertAssessmentService, "getQuestions" | "submitAnswers">;
 }
 
 const isUploadedFile = (value: unknown): value is UploadedFile => {
@@ -44,9 +49,62 @@ const resolveFileFromBody = (body: Record<string, unknown>): UploadedFile | null
 
 export const createStudentRoutes = ({
   requireStudentAuth,
-  certificateUploadService
+  certificateUploadService,
+  likertAssessmentService = {
+    async getQuestions() {
+      throw new Error("likertAssessmentService is not configured");
+    },
+    async submitAnswers() {
+      throw new Error("likertAssessmentService is not configured");
+    }
+  }
 }: StudentRouteDependencies) => {
   const student = new Hono();
+
+  student.get("/assessments/questions", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const result = await likertAssessmentService.getQuestions();
+    return c.json(result, 200);
+  });
+
+  student.post("/assessments/submissions", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    let body: unknown;
+
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const answers = (body as { answers?: unknown })?.answers;
+    if (!Array.isArray(answers)) {
+      return c.json({ message: "answers must include exactly 50 likert items" }, 400);
+    }
+
+    try {
+      const result = await likertAssessmentService.submitAnswers({
+        studentId: studentAuth.studentId,
+        answers: answers as Array<{ questionId: number; score: number }>
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof InvalidLikertAnswersError) {
+        return c.json({ message: error.message }, 400);
+      }
+
+      throw error;
+    }
+  });
 
   student.post("/certificates/upload", requireStudentAuth, async (c) => {
     const studentAuth = c.get("studentAuth");

--- a/tests/assessment/likert-assessment.test.ts
+++ b/tests/assessment/likert-assessment.test.ts
@@ -1,0 +1,278 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createLikertAssessmentService,
+  type LikertAssessmentSubmissionRepository
+} from "../../src/modules/assessment/likert.ts";
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+const makeAnswers = () =>
+  Array.from({ length: 50 }, (_, index) => ({
+    questionId: index + 1,
+    score: ((index % 5) + 1)
+  }));
+
+test("likert assessment service should return 50 questions", async () => {
+  const repo: LikertAssessmentSubmissionRepository = {
+    async findSubmissionByStudentId() {
+      return null;
+    },
+    async createSubmission() {
+      return 1;
+    },
+    async updateSubmission() {
+      return;
+    }
+  };
+
+  const service = createLikertAssessmentService({
+    submissionRepo: repo
+  });
+
+  const result = await service.getQuestions();
+
+  assert.equal(result.questions.length, 50);
+  assert.equal(result.questions[0].questionId, 1);
+  assert.equal(result.questions[49].questionId, 50);
+});
+
+test("likert assessment submit should overwrite previous answers for same student", async () => {
+  const store = new Map<number, { id: number; answersJson: string; answerCount: number }>();
+  let nextId = 1;
+
+  const repo: LikertAssessmentSubmissionRepository = {
+    async findSubmissionByStudentId(studentId) {
+      const hit = store.get(studentId);
+      if (!hit) {
+        return null;
+      }
+
+      return {
+        id: hit.id,
+        studentId,
+        answersJson: hit.answersJson,
+        answerCount: hit.answerCount
+      };
+    },
+    async createSubmission(input) {
+      const id = nextId++;
+      store.set(input.studentId, {
+        id,
+        answersJson: input.answersJson,
+        answerCount: input.answerCount
+      });
+      return id;
+    },
+    async updateSubmission(input) {
+      store.set(input.studentId, {
+        id: input.id,
+        answersJson: input.answersJson,
+        answerCount: input.answerCount
+      });
+    }
+  };
+
+  const service = createLikertAssessmentService({
+    submissionRepo: repo
+  });
+
+  const first = await service.submitAnswers({
+    studentId: 1001,
+    answers: makeAnswers()
+  });
+
+  const second = await service.submitAnswers({
+    studentId: 1001,
+    answers: makeAnswers().map((item) => ({ ...item, score: 5 }))
+  });
+
+  assert.equal(first.overwritten, false);
+  assert.equal(second.overwritten, true);
+  assert.equal(store.size, 1);
+});
+
+test("GET /student/assessments/questions should return 50 questions after login", async () => {
+  const repo: LikertAssessmentSubmissionRepository = {
+    async findSubmissionByStudentId() {
+      return null;
+    },
+    async createSubmission() {
+      return 1;
+    },
+    async updateSubmission() {
+      return;
+    }
+  };
+
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: createLikertAssessmentService({
+        submissionRepo: repo
+      })
+    })
+  );
+
+  const response = await app.request("/student/assessments/questions", {
+    headers: {
+      authorization: "Bearer valid-token"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.questions.length, 50);
+});
+
+test("POST /student/assessments/submissions should return 400 when answers is not complete 50", async () => {
+  const repo: LikertAssessmentSubmissionRepository = {
+    async findSubmissionByStudentId() {
+      return null;
+    },
+    async createSubmission() {
+      return 1;
+    },
+    async updateSubmission() {
+      return;
+    }
+  };
+
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: createLikertAssessmentService({
+        submissionRepo: repo
+      })
+    })
+  );
+
+  const response = await app.request("/student/assessments/submissions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      answers: makeAnswers().slice(0, 49)
+    })
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    message: "answers must include exactly 50 likert items"
+  });
+});
+
+test("POST /student/assessments/submissions should persist and overwrite consistently", async () => {
+  const store = new Map<number, { id: number; answersJson: string; answerCount: number }>();
+  let nextId = 1;
+
+  const repo: LikertAssessmentSubmissionRepository = {
+    async findSubmissionByStudentId(studentId) {
+      const hit = store.get(studentId);
+      if (!hit) {
+        return null;
+      }
+
+      return {
+        id: hit.id,
+        studentId,
+        answersJson: hit.answersJson,
+        answerCount: hit.answerCount
+      };
+    },
+    async createSubmission(input) {
+      const id = nextId++;
+      store.set(input.studentId, {
+        id,
+        answersJson: input.answersJson,
+        answerCount: input.answerCount
+      });
+      return id;
+    },
+    async updateSubmission(input) {
+      store.set(input.studentId, {
+        id: input.id,
+        answersJson: input.answersJson,
+        answerCount: input.answerCount
+      });
+    }
+  };
+
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: createLikertAssessmentService({
+        submissionRepo: repo
+      })
+    })
+  );
+
+  const first = await app.request("/student/assessments/submissions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({ answers: makeAnswers() })
+  });
+
+  const second = await app.request("/student/assessments/submissions", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      answers: makeAnswers().map((item) => ({ ...item, score: 5 }))
+    })
+  });
+
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200);
+
+  const firstPayload = await first.json();
+  const secondPayload = await second.json();
+
+  assert.equal(firstPayload.overwritten, false);
+  assert.equal(secondPayload.overwritten, true);
+  assert.equal(store.size, 1);
+});

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 8, "journal should contain at least 8 entries");
+  assert.ok(entries.length >= 9, "journal should contain at least 9 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -155,4 +155,18 @@ test("0008 migration file should include enrollment_profiles source table", () =
   assert.match(migrationSql, /`student_no`\s+varchar\(32\)\s+NOT\s+NULL/i);
   assert.match(migrationSql, /`score`\s+int/i);
   assert.match(migrationSql, /`admission_year`\s+int/i);
+});
+
+test("0009 migration file should include assessment_submissions table", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0009 = migrationFiles.find((fileName) => /^0009_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0009, "expected a 0009 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0009), "utf8");
+
+  assert.match(migrationSql, /CREATE TABLE\s+`assessment_submissions`/i);
+  assert.match(migrationSql, /`student_id`\s+int\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /`answers_json`\s+text\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /UNIQUE\(`student_id`\)/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  assessmentSubmissions,
   activities,
   authScopes,
   auditLogs,
@@ -98,4 +99,12 @@ test("schema should include enrollment_profiles read-only source table", () => {
   assert.equal(enrollmentProfiles.studentNo.name, "student_no");
   assert.equal(enrollmentProfiles.score.name, "score");
   assert.equal(enrollmentProfiles.admissionYear.name, "admission_year");
+});
+
+test("schema should include assessment_submissions overwrite table", () => {
+  assert.equal(assessmentSubmissions[Symbol.for("drizzle:Name")], "assessment_submissions");
+  assert.equal(assessmentSubmissions.studentId.name, "student_id");
+  assert.equal(assessmentSubmissions.questionSetVersion.name, "question_set_version");
+  assert.equal(assessmentSubmissions.answersJson.name, "answers_json");
+  assert.equal(assessmentSubmissions.answerCount.name, "answer_count");
 });


### PR DESCRIPTION
## 变更说明
- 新增测评题库服务（50题 Likert，1-5分）
- 新增学生端接口：
  - GET /student/assessments/questions（拉取题目）
  - POST /student/assessments/submissions（提交答案）
- 新增 assessment_submissions 表与 0009 迁移
- 提交策略采用“覆盖”：同一学生重复提交会覆盖上一版，并返回 overwritten=true
- 补充服务层、路由层、schema/migration 测试

## 验收对应
- [x] 可拉取题目
- [x] 提交后落库完整答案
- [x] 重复提交行为一致（覆盖策略）

## 验证
- pnpm test（95/95 通过）

Closes #15
