### PR TITLE
feat: 实现测评计算与解释服务（0.4/0.4/0.2）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
 import { createLikertAssessmentService } from "./modules/assessment/likert.js";
+import { createLikertAssessmentResultService } from "./modules/assessment/result.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -227,6 +228,10 @@ const likertAssessmentSubmissionRepo = {
 
 const likertAssessmentService = createLikertAssessmentService({
   submissionRepo: likertAssessmentSubmissionRepo
+});
+
+const likertAssessmentResultService = createLikertAssessmentResultService({
+  resultRepo: likertAssessmentSubmissionRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -830,7 +835,8 @@ app.route(
   createStudentRoutes({
     requireStudentAuth,
     certificateUploadService,
-    likertAssessmentService
+    likertAssessmentService,
+    likertAssessmentResultService
   })
 );
 

--- a/src/modules/assessment/likert.ts
+++ b/src/modules/assessment/likert.ts
@@ -68,9 +68,9 @@ export class InvalidLikertAnswersError extends Error {
   }
 }
 
-const LIKERT_QUESTION_COUNT = 50;
+export const LIKERT_QUESTION_COUNT = 50;
 
-const LIKERT_QUESTIONS: LikertQuestion[] = [
+export const LIKERT_QUESTIONS: LikertQuestion[] = [
   { questionId: 1, content: "我会主动关注就业与升学相关信息。", dimension: "interest" },
   { questionId: 2, content: "我愿意持续投入时间探索未来职业方向。", dimension: "interest" },
   { questionId: 3, content: "我对参加职业体验活动有较强兴趣。", dimension: "interest" },

--- a/src/modules/assessment/result.ts
+++ b/src/modules/assessment/result.ts
@@ -1,0 +1,178 @@
+import { LIKERT_QUESTIONS, type LikertAnswerInput } from "./likert.js";
+
+export type AssessmentDirection = "employment" | "postgraduate" | "civil_service";
+
+export interface LikertAssessmentResultRepository {
+  findSubmissionByStudentId(studentId: number): Promise<{
+    id: number;
+    studentId: number;
+    answersJson: string;
+  } | null>;
+}
+
+export interface GetLikertAssessmentResultInput {
+  studentId: number;
+}
+
+export interface LikertAssessmentResult {
+  dimensionScores: {
+    interest: number;
+    ability: number;
+    value: number;
+  };
+  weights: {
+    interest: 0.4;
+    ability: 0.4;
+    value: 0.2;
+  };
+  scores: Array<{
+    direction: AssessmentDirection;
+    score: number;
+  }>;
+  recommendation: {
+    direction: AssessmentDirection;
+    reason: string;
+  };
+}
+
+export interface LikertAssessmentResultService {
+  getResult(input: GetLikertAssessmentResultInput): Promise<LikertAssessmentResult>;
+}
+
+export interface CreateLikertAssessmentResultServiceInput {
+  resultRepo: LikertAssessmentResultRepository;
+}
+
+export class LikertAssessmentResultNotFoundError extends Error {
+  constructor() {
+    super("assessment submission not found");
+    this.name = "LikertAssessmentResultNotFoundError";
+  }
+}
+
+const roundToOneDecimal = (value: number): number => {
+  return Math.round(value * 10) / 10;
+};
+
+const averageToHundredScale = (scores: number[]): number => {
+  if (scores.length === 0) {
+    return 0;
+  }
+
+  const average = scores.reduce((sum, value) => sum + value, 0) / scores.length;
+  return roundToOneDecimal((average / 5) * 100);
+};
+
+const parseAnswers = (answersJson: string): LikertAnswerInput[] => {
+  const parsed = JSON.parse(answersJson) as unknown;
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return parsed
+    .filter((item): item is LikertAnswerInput => {
+      if (!item || typeof item !== "object") {
+        return false;
+      }
+      const questionId = (item as { questionId?: unknown }).questionId;
+      const score = (item as { score?: unknown }).score;
+      return Number.isInteger(questionId) && Number.isInteger(score);
+    })
+    .map((item) => ({
+      questionId: item.questionId,
+      score: item.score
+    }));
+};
+
+const resolveRecommendationReason = (direction: AssessmentDirection): string => {
+  switch (direction) {
+    case "employment":
+      return "你的兴趣驱动与执行能力匹配较高，建议优先走就业实践路径。";
+    case "postgraduate":
+      return "你的学术兴趣与价值稳定性较强，建议优先考虑考研深造。";
+    case "civil_service":
+      return "你的价值稳定性与执行力较高，建议优先考虑考公方向。";
+    default:
+      return "建议根据优势维度继续探索最适合的方向。";
+  }
+};
+
+export const createLikertAssessmentResultService = ({
+  resultRepo
+}: CreateLikertAssessmentResultServiceInput): LikertAssessmentResultService => {
+  return {
+    async getResult({ studentId }: GetLikertAssessmentResultInput): Promise<LikertAssessmentResult> {
+      const submission = await resultRepo.findSubmissionByStudentId(studentId);
+      if (!submission) {
+        throw new LikertAssessmentResultNotFoundError();
+      }
+
+      const answers = parseAnswers(submission.answersJson);
+      const scoreByQuestionId = new Map<number, number>();
+      for (const answer of answers) {
+        scoreByQuestionId.set(answer.questionId, answer.score);
+      }
+
+      const interestScores: number[] = [];
+      const abilityScores: number[] = [];
+      const valueScores: number[] = [];
+
+      for (const question of LIKERT_QUESTIONS) {
+        const score = scoreByQuestionId.get(question.questionId);
+        if (!score) {
+          continue;
+        }
+
+        if (question.dimension === "interest") {
+          interestScores.push(score);
+          continue;
+        }
+
+        if (question.dimension === "ability") {
+          abilityScores.push(score);
+          continue;
+        }
+
+        valueScores.push(score);
+      }
+
+      const dimensionScores = {
+        interest: averageToHundredScale(interestScores),
+        ability: averageToHundredScale(abilityScores),
+        value: averageToHundredScale(valueScores)
+      };
+
+      const employment = roundToOneDecimal(
+        dimensionScores.interest * 0.4 + dimensionScores.ability * 0.4 + dimensionScores.value * 0.2
+      );
+      const postgraduate = roundToOneDecimal(
+        dimensionScores.interest * 0.4 + dimensionScores.value * 0.4 + dimensionScores.ability * 0.2
+      );
+      const civilService = roundToOneDecimal(
+        dimensionScores.value * 0.4 + dimensionScores.ability * 0.4 + dimensionScores.interest * 0.2
+      );
+
+      const scores: LikertAssessmentResult["scores"] = [
+        { direction: "employment", score: employment },
+        { direction: "postgraduate", score: postgraduate },
+        { direction: "civil_service", score: civilService }
+      ].sort((left, right) => right.score - left.score);
+
+      const recommendationDirection = scores[0]?.direction ?? "employment";
+
+      return {
+        dimensionScores,
+        weights: {
+          interest: 0.4,
+          ability: 0.4,
+          value: 0.2
+        },
+        scores,
+        recommendation: {
+          direction: recommendationDirection,
+          reason: resolveRecommendationReason(recommendationDirection)
+        }
+      };
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -10,11 +10,16 @@ import {
   InvalidLikertAnswersError,
   type LikertAssessmentService
 } from "../modules/assessment/likert.js";
+import {
+  LikertAssessmentResultNotFoundError,
+  type LikertAssessmentResultService
+} from "../modules/assessment/result.js";
 
 export interface StudentRouteDependencies {
   requireStudentAuth: MiddlewareHandler;
   certificateUploadService: CertificateUploadService;
   likertAssessmentService?: Pick<LikertAssessmentService, "getQuestions" | "submitAnswers">;
+  likertAssessmentResultService?: Pick<LikertAssessmentResultService, "getResult">;
 }
 
 const isUploadedFile = (value: unknown): value is UploadedFile => {
@@ -56,6 +61,11 @@ export const createStudentRoutes = ({
     },
     async submitAnswers() {
       throw new Error("likertAssessmentService is not configured");
+    }
+  },
+  likertAssessmentResultService = {
+    async getResult() {
+      throw new Error("likertAssessmentResultService is not configured");
     }
   }
 }: StudentRouteDependencies) => {
@@ -100,6 +110,26 @@ export const createStudentRoutes = ({
     } catch (error) {
       if (error instanceof InvalidLikertAnswersError) {
         return c.json({ message: error.message }, 400);
+      }
+
+      throw error;
+    }
+  });
+
+  student.get("/assessments/result", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    try {
+      const result = await likertAssessmentResultService.getResult({
+        studentId: studentAuth.studentId
+      });
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof LikertAssessmentResultNotFoundError) {
+        return c.json({ message: "assessment submission not found" }, 404);
       }
 
       throw error;

--- a/tests/assessment/likert-result.test.ts
+++ b/tests/assessment/likert-result.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createLikertAssessmentResultService,
+  LikertAssessmentResultNotFoundError,
+  type LikertAssessmentResultRepository
+} from "../../src/modules/assessment/result.ts";
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+const makeAnswers = (score = 4) =>
+  Array.from({ length: 50 }, (_, index) => ({
+    questionId: index + 1,
+    score
+  }));
+
+test("assessment result service should calculate three directions with 0.4/0.4/0.2", async () => {
+  const repo: LikertAssessmentResultRepository = {
+    async findSubmissionByStudentId() {
+      return {
+        id: 1,
+        studentId: 1001,
+        answersJson: JSON.stringify(makeAnswers(5))
+      };
+    }
+  };
+
+  const service = createLikertAssessmentResultService({ resultRepo: repo });
+  const result = await service.getResult({ studentId: 1001 });
+
+  assert.equal(result.weights.interest, 0.4);
+  assert.equal(result.weights.ability, 0.4);
+  assert.equal(result.weights.value, 0.2);
+  assert.equal(result.scores.length, 3);
+  assert.ok(result.scores.every((item) => item.score >= 0 && item.score <= 100));
+  assert.ok(result.recommendation.direction);
+  assert.ok(result.recommendation.reason.length > 0);
+});
+
+test("assessment result service should throw not found when submission missing", async () => {
+  const repo: LikertAssessmentResultRepository = {
+    async findSubmissionByStudentId() {
+      return null;
+    }
+  };
+
+  const service = createLikertAssessmentResultService({ resultRepo: repo });
+
+  await assert.rejects(
+    async () => {
+      await service.getResult({ studentId: 1001 });
+    },
+    (error: unknown) => error instanceof LikertAssessmentResultNotFoundError
+  );
+});
+
+test("GET /student/assessments/result should return result after login", async () => {
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: {
+        async getQuestions() {
+          return { version: "v1" as const, scaleMin: 1 as const, scaleMax: 5 as const, questions: [] };
+        },
+        async submitAnswers() {
+          return { submissionId: 1, overwritten: false, answerCount: 50, submittedAt: new Date().toISOString() };
+        }
+      },
+      likertAssessmentResultService: {
+        async getResult() {
+          return {
+            dimensionScores: { interest: 88, ability: 90, value: 85 },
+            weights: { interest: 0.4 as const, ability: 0.4 as const, value: 0.2 as const },
+            scores: [
+              { direction: "employment" as const, score: 88.2 },
+              { direction: "postgraduate" as const, score: 87.6 },
+              { direction: "civil_service" as const, score: 88.6 }
+            ],
+            recommendation: {
+              direction: "civil_service" as const,
+              reason: "你的价值稳定性与执行力较高，建议优先考虑考公方向。"
+            }
+          };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/student/assessments/result", {
+    headers: {
+      authorization: "Bearer valid-token"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.scores.length, 3);
+  assert.equal(payload.recommendation.direction, "civil_service");
+});


### PR DESCRIPTION
## 变更说明
- 新增测评结果计算服务（基于已提交50题答案）
- 新增接口：GET /student/assessments/result
- 采用 0.4/0.4/0.2 权重输出三方向分数（就业/考研/考公）
- 返回推荐方向与解释文案
- 无提交记录时返回 404（assessment submission not found）

## 验证
- pnpm test（98/98 通过）

Closes #16
