### PR TITLE
feat: 实现榜样匹配规则引擎（同校同专业优先+分差兜底）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "@hono/node-server";
-import { and, eq, gte, lt } from "drizzle-orm";
+import { and, eq, gte, lt, ne } from "drizzle-orm";
 import { Hono } from "hono";
 import path from "node:path";
 import { env } from "./config/env.js";
@@ -47,6 +47,7 @@ import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/tok
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
 import { createLikertAssessmentService } from "./modules/assessment/likert.js";
 import { createLikertAssessmentResultService } from "./modules/assessment/result.js";
+import { createRoleModelMatchingService } from "./modules/role-model/matching.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -232,6 +233,51 @@ const likertAssessmentService = createLikertAssessmentService({
 
 const likertAssessmentResultService = createLikertAssessmentResultService({
   resultRepo: likertAssessmentSubmissionRepo
+});
+
+const roleModelMatchingRepo = {
+  async findStudentEnrollmentProfile(studentNo: string) {
+    const records = await db
+      .select({
+        studentNo: enrollmentProfiles.studentNo,
+        schoolName: enrollmentProfiles.schoolName,
+        majorName: enrollmentProfiles.majorName,
+        score: enrollmentProfiles.score
+      })
+      .from(enrollmentProfiles)
+      .where(eq(enrollmentProfiles.studentNo, studentNo))
+      .limit(1);
+
+    return records[0] ?? null;
+  },
+  async listRoleModelCandidates(direction: "employment" | "postgraduate" | "civil_service") {
+    const records = await db
+      .select({
+        studentNo: enrollmentProfiles.studentNo,
+        name: enrollmentProfiles.name,
+        schoolName: enrollmentProfiles.schoolName,
+        majorName: enrollmentProfiles.majorName,
+        score: enrollmentProfiles.score,
+        direction: reports.direction
+      })
+      .from(enrollmentProfiles)
+      .innerJoin(students, eq(students.studentNo, enrollmentProfiles.studentNo))
+      .innerJoin(reports, and(eq(reports.studentId, students.id), eq(reports.direction, direction)))
+      .where(ne(students.studentNo, ""));
+
+    return records.map((record) => ({
+      studentNo: record.studentNo,
+      name: record.name ?? "匿名榜样",
+      schoolName: record.schoolName,
+      majorName: record.majorName,
+      score: record.score,
+      direction: record.direction
+    }));
+  }
+};
+
+const roleModelMatchingService = createRoleModelMatchingService({
+  roleModelRepo: roleModelMatchingRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -836,7 +882,8 @@ app.route(
     requireStudentAuth,
     certificateUploadService,
     likertAssessmentService,
-    likertAssessmentResultService
+    likertAssessmentResultService,
+    roleModelMatchingService
   })
 );
 

--- a/src/modules/role-model/matching.ts
+++ b/src/modules/role-model/matching.ts
@@ -1,0 +1,108 @@
+export type RoleModelDirection = "employment" | "postgraduate" | "civil_service";
+export type RoleModelMatchingStrategy = "same_school_same_major" | "score_gap_fallback";
+
+export interface StudentEnrollmentProfile {
+  studentNo: string;
+  schoolName: string | null;
+  majorName: string | null;
+  score: number | null;
+}
+
+export interface RoleModelCandidate {
+  studentNo: string;
+  name: string;
+  schoolName: string | null;
+  majorName: string | null;
+  score: number | null;
+  direction: RoleModelDirection;
+}
+
+export interface RoleModelMatchingRepository {
+  findStudentEnrollmentProfile(studentNo: string): Promise<StudentEnrollmentProfile | null>;
+  listRoleModelCandidates(direction: RoleModelDirection): Promise<RoleModelCandidate[]>;
+}
+
+export interface MatchRoleModelsInput {
+  studentNo: string;
+  direction: RoleModelDirection;
+}
+
+export interface MatchRoleModelsResult {
+  strategy: RoleModelMatchingStrategy;
+  matched: Array<RoleModelCandidate & { scoreGap: number | null }>;
+}
+
+export interface RoleModelMatchingService {
+  matchRoleModels(input: MatchRoleModelsInput): Promise<MatchRoleModelsResult>;
+}
+
+export interface CreateRoleModelMatchingServiceInput {
+  roleModelRepo: RoleModelMatchingRepository;
+  maxMatched?: number;
+}
+
+export class RoleModelMatchingNotFoundError extends Error {
+  constructor() {
+    super("student enrollment profile not found");
+    this.name = "RoleModelMatchingNotFoundError";
+  }
+}
+
+const resolveScoreGap = (selfScore: number | null, candidateScore: number | null): number | null => {
+  if (selfScore === null || candidateScore === null) {
+    return null;
+  }
+
+  return Math.abs(selfScore - candidateScore);
+};
+
+const sortByScoreGap = (
+  selfScore: number | null,
+  candidates: RoleModelCandidate[]
+): Array<RoleModelCandidate & { scoreGap: number | null }> => {
+  return candidates
+    .map((candidate) => ({
+      ...candidate,
+      scoreGap: resolveScoreGap(selfScore, candidate.score)
+    }))
+    .sort((left, right) => {
+      const leftGap = left.scoreGap ?? Number.MAX_SAFE_INTEGER;
+      const rightGap = right.scoreGap ?? Number.MAX_SAFE_INTEGER;
+      return leftGap - rightGap;
+    });
+};
+
+export const createRoleModelMatchingService = ({
+  roleModelRepo,
+  maxMatched = 10
+}: CreateRoleModelMatchingServiceInput): RoleModelMatchingService => {
+  return {
+    async matchRoleModels({ studentNo, direction }: MatchRoleModelsInput): Promise<MatchRoleModelsResult> {
+      const studentProfile = await roleModelRepo.findStudentEnrollmentProfile(studentNo);
+      if (!studentProfile) {
+        throw new RoleModelMatchingNotFoundError();
+      }
+
+      const allCandidates = (await roleModelRepo.listRoleModelCandidates(direction)).filter(
+        (candidate) => candidate.studentNo !== studentNo
+      );
+
+      const sameSchoolSameMajorCandidates = allCandidates.filter(
+        (candidate) =>
+          Boolean(studentProfile.schoolName) &&
+          Boolean(studentProfile.majorName) &&
+          candidate.schoolName === studentProfile.schoolName &&
+          candidate.majorName === studentProfile.majorName
+      );
+
+      const useSameSchoolMajor = sameSchoolSameMajorCandidates.length > 0;
+      const baseCandidates = useSameSchoolMajor ? sameSchoolSameMajorCandidates : allCandidates;
+      const sorted = sortByScoreGap(studentProfile.score, baseCandidates);
+
+      return {
+        strategy: useSameSchoolMajor ? "same_school_same_major" : "score_gap_fallback",
+        matched: sorted.slice(0, maxMatched)
+      };
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -14,12 +14,18 @@ import {
   LikertAssessmentResultNotFoundError,
   type LikertAssessmentResultService
 } from "../modules/assessment/result.js";
+import {
+  RoleModelMatchingNotFoundError,
+  type RoleModelDirection,
+  type RoleModelMatchingService
+} from "../modules/role-model/matching.js";
 
 export interface StudentRouteDependencies {
   requireStudentAuth: MiddlewareHandler;
   certificateUploadService: CertificateUploadService;
   likertAssessmentService?: Pick<LikertAssessmentService, "getQuestions" | "submitAnswers">;
   likertAssessmentResultService?: Pick<LikertAssessmentResultService, "getResult">;
+  roleModelMatchingService?: Pick<RoleModelMatchingService, "matchRoleModels">;
 }
 
 const isUploadedFile = (value: unknown): value is UploadedFile => {
@@ -66,6 +72,11 @@ export const createStudentRoutes = ({
   likertAssessmentResultService = {
     async getResult() {
       throw new Error("likertAssessmentResultService is not configured");
+    }
+  },
+  roleModelMatchingService = {
+    async matchRoleModels() {
+      throw new Error("roleModelMatchingService is not configured");
     }
   }
 }: StudentRouteDependencies) => {
@@ -130,6 +141,34 @@ export const createStudentRoutes = ({
     } catch (error) {
       if (error instanceof LikertAssessmentResultNotFoundError) {
         return c.json({ message: "assessment submission not found" }, 404);
+      }
+
+      throw error;
+    }
+  });
+
+  student.get("/role-models/match", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const directionInput = c.req.query("direction");
+    const direction: RoleModelDirection =
+      directionInput === "postgraduate" || directionInput === "civil_service"
+        ? directionInput
+        : "employment";
+
+    try {
+      const result = await roleModelMatchingService.matchRoleModels({
+        studentNo: studentAuth.studentNo,
+        direction
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof RoleModelMatchingNotFoundError) {
+        return c.json({ message: "student enrollment profile not found" }, 404);
       }
 
       throw error;

--- a/tests/role-model/matching.test.ts
+++ b/tests/role-model/matching.test.ts
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createRoleModelMatchingService,
+  type RoleModelMatchingRepository
+} from "../../src/modules/role-model/matching.ts";
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+test("role model matching should prioritize same school and major", async () => {
+  const repo: RoleModelMatchingRepository = {
+    async findStudentEnrollmentProfile() {
+      return {
+        studentNo: "S20261001",
+        schoolName: "华南理工大学",
+        majorName: "软件工程",
+        score: 620
+      };
+    },
+    async listRoleModelCandidates() {
+      return [
+        { studentNo: "A", name: "A", schoolName: "其他学校", majorName: "软件工程", score: 620, direction: "employment" as const },
+        { studentNo: "B", name: "B", schoolName: "华南理工大学", majorName: "软件工程", score: 630, direction: "employment" as const }
+      ];
+    }
+  };
+
+  const service = createRoleModelMatchingService({ roleModelRepo: repo });
+  const result = await service.matchRoleModels({
+    studentNo: "S20261001",
+    direction: "employment"
+  });
+
+  assert.equal(result.matched.length, 1);
+  assert.equal(result.matched[0].studentNo, "B");
+  assert.equal(result.strategy, "same_school_same_major");
+});
+
+test("role model matching should fallback to score gap when no same school major", async () => {
+  const repo: RoleModelMatchingRepository = {
+    async findStudentEnrollmentProfile() {
+      return {
+        studentNo: "S20261001",
+        schoolName: "华南理工大学",
+        majorName: "软件工程",
+        score: 620
+      };
+    },
+    async listRoleModelCandidates() {
+      return [
+        { studentNo: "A", name: "A", schoolName: "其他学校", majorName: "金融学", score: 619, direction: "employment" as const },
+        { studentNo: "B", name: "B", schoolName: "其他学校", majorName: "法学", score: 650, direction: "employment" as const }
+      ];
+    }
+  };
+
+  const service = createRoleModelMatchingService({ roleModelRepo: repo });
+  const result = await service.matchRoleModels({
+    studentNo: "S20261001",
+    direction: "employment"
+  });
+
+  assert.equal(result.strategy, "score_gap_fallback");
+  assert.equal(result.matched[0].studentNo, "A");
+});
+
+test("GET /student/role-models/match should return matched role models", async () => {
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: {
+        async getQuestions() {
+          return { version: "v1" as const, scaleMin: 1 as const, scaleMax: 5 as const, questions: [] };
+        },
+        async submitAnswers() {
+          return { submissionId: 1, overwritten: false, answerCount: 50, submittedAt: new Date().toISOString() };
+        }
+      },
+      likertAssessmentResultService: {
+        async getResult() {
+          return {
+            dimensionScores: { interest: 80, ability: 82, value: 84 },
+            weights: { interest: 0.4 as const, ability: 0.4 as const, value: 0.2 as const },
+            scores: [
+              { direction: "employment" as const, score: 82 },
+              { direction: "postgraduate" as const, score: 81 },
+              { direction: "civil_service" as const, score: 80 }
+            ],
+            recommendation: { direction: "employment" as const, reason: "test" }
+          };
+        }
+      },
+      roleModelMatchingService: {
+        async matchRoleModels() {
+          return {
+            strategy: "same_school_same_major" as const,
+            matched: [
+              {
+                studentNo: "S20250001",
+                name: "李同学",
+                schoolName: "华南理工大学",
+                majorName: "软件工程",
+                score: 618,
+                scoreGap: 2,
+                direction: "employment" as const
+              }
+            ]
+          };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/student/role-models/match?direction=employment", {
+    headers: {
+      authorization: "Bearer valid-token"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.strategy, "same_school_same_major");
+  assert.equal(payload.matched.length, 1);
+});


### PR DESCRIPTION
## 变更说明
- 新增榜样匹配服务：同校同专业优先，分差兜底
- 新增接口：GET /student/role-models/match?direction=employment|postgraduate|civil_service
- 匹配结果返回策略与 scoreGap
- 无学生招生画像时返回 404
- 补充服务层与路由层测试

## 验证
- pnpm test（101/101 通过）

Closes #17
