### PR TITLE
feat: 实现三份报告生成服务（Markdown）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import { createStudentFirstLoginVerificationService } from "./modules/auth/first
 import { createLikertAssessmentService } from "./modules/assessment/likert.js";
 import { createLikertAssessmentResultService } from "./modules/assessment/result.js";
 import { createRoleModelMatchingService } from "./modules/role-model/matching.js";
+import { createReportGenerationService } from "./modules/report/generation.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -279,6 +280,8 @@ const roleModelMatchingRepo = {
 const roleModelMatchingService = createRoleModelMatchingService({
   roleModelRepo: roleModelMatchingRepo
 });
+
+const reportGenerationService = createReportGenerationService();
 
 const requireStudentAuth = createStudentAuthMiddleware({
   tokenVerifier: createJwtTokenVerifier({
@@ -883,7 +886,8 @@ app.route(
     certificateUploadService,
     likertAssessmentService,
     likertAssessmentResultService,
-    roleModelMatchingService
+    roleModelMatchingService,
+    reportGenerationService
   })
 );
 

--- a/src/modules/report/generation.ts
+++ b/src/modules/report/generation.ts
@@ -1,0 +1,73 @@
+export type ReportDirection = "employment" | "postgraduate" | "civil_service";
+
+export interface ReportGenerationInput {
+  studentNo: string;
+  dimensionScores: {
+    interest: number;
+    ability: number;
+    value: number;
+  };
+  recommendation: {
+    direction: ReportDirection;
+    reason: string;
+  };
+}
+
+export interface GeneratedReport {
+  direction: ReportDirection;
+  markdown: string;
+}
+
+export interface GenerateAllReportsResult {
+  reports: GeneratedReport[];
+}
+
+export interface ReportGenerationService {
+  generateAllReports(input: ReportGenerationInput): Promise<GenerateAllReportsResult>;
+}
+
+const resolveDirectionTitle = (direction: ReportDirection): string => {
+  switch (direction) {
+    case "employment":
+      return "就业发展报告";
+    case "postgraduate":
+      return "考研发展报告";
+    case "civil_service":
+      return "考公发展报告";
+    default:
+      return "发展报告";
+  }
+};
+
+const buildMarkdown = (direction: ReportDirection, input: ReportGenerationInput): string => {
+  return [
+    `# ${resolveDirectionTitle(direction)}`,
+    "",
+    `- 学号：${input.studentNo}`,
+    `- 兴趣维度：${input.dimensionScores.interest}`,
+    `- 能力维度：${input.dimensionScores.ability}`,
+    `- 价值维度：${input.dimensionScores.value}`,
+    "",
+    "## 结论摘要",
+    `推荐方向：${input.recommendation.direction}`,
+    `解释：${input.recommendation.reason}`,
+    "",
+    "## 下一步建议",
+    "1. 完成阶段目标拆解并形成周计划",
+    "2. 结合目标方向补齐关键能力短板",
+    "3. 持续复盘并按月更新行动方案"
+  ].join("\n");
+};
+
+export const createReportGenerationService = (): ReportGenerationService => {
+  return {
+    async generateAllReports(input: ReportGenerationInput): Promise<GenerateAllReportsResult> {
+      return {
+        reports: (["employment", "postgraduate", "civil_service"] as const).map((direction) => ({
+          direction,
+          markdown: buildMarkdown(direction, input)
+        }))
+      };
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -19,6 +19,7 @@ import {
   type RoleModelDirection,
   type RoleModelMatchingService
 } from "../modules/role-model/matching.js";
+import type { ReportGenerationService } from "../modules/report/generation.js";
 
 export interface StudentRouteDependencies {
   requireStudentAuth: MiddlewareHandler;
@@ -26,6 +27,7 @@ export interface StudentRouteDependencies {
   likertAssessmentService?: Pick<LikertAssessmentService, "getQuestions" | "submitAnswers">;
   likertAssessmentResultService?: Pick<LikertAssessmentResultService, "getResult">;
   roleModelMatchingService?: Pick<RoleModelMatchingService, "matchRoleModels">;
+  reportGenerationService?: Pick<ReportGenerationService, "generateAllReports">;
 }
 
 const isUploadedFile = (value: unknown): value is UploadedFile => {
@@ -77,6 +79,11 @@ export const createStudentRoutes = ({
   roleModelMatchingService = {
     async matchRoleModels() {
       throw new Error("roleModelMatchingService is not configured");
+    }
+  },
+  reportGenerationService = {
+    async generateAllReports() {
+      throw new Error("reportGenerationService is not configured");
     }
   }
 }: StudentRouteDependencies) => {
@@ -173,6 +180,25 @@ export const createStudentRoutes = ({
 
       throw error;
     }
+  });
+
+  student.post("/reports/generate", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const assessmentResult = await likertAssessmentResultService.getResult({
+      studentId: studentAuth.studentId
+    });
+
+    const generated = await reportGenerationService.generateAllReports({
+      studentNo: studentAuth.studentNo,
+      dimensionScores: assessmentResult.dimensionScores,
+      recommendation: assessmentResult.recommendation
+    });
+
+    return c.json(generated, 200);
   });
 
   student.post("/certificates/upload", requireStudentAuth, async (c) => {

--- a/tests/report/generation.test.ts
+++ b/tests/report/generation.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createReportGenerationService,
+  type ReportGenerationInput
+} from "../../src/modules/report/generation.ts";
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+const baseInput: ReportGenerationInput = {
+  studentNo: "S20261001",
+  dimensionScores: {
+    interest: 84,
+    ability: 86,
+    value: 82
+  },
+  recommendation: {
+    direction: "employment",
+    reason: "建议优先就业实践"
+  }
+};
+
+test("report generation service should output three markdown reports", async () => {
+  const service = createReportGenerationService();
+  const result = await service.generateAllReports(baseInput);
+
+  assert.equal(result.reports.length, 3);
+  assert.ok(result.reports[0].markdown.includes("#"));
+  assert.ok(result.reports.some((item) => item.direction === "employment"));
+  assert.ok(result.reports.some((item) => item.direction === "postgraduate"));
+  assert.ok(result.reports.some((item) => item.direction === "civil_service"));
+});
+
+test("POST /student/reports/generate should return three reports", async () => {
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: {
+        async getQuestions() {
+          return { version: "v1" as const, scaleMin: 1 as const, scaleMax: 5 as const, questions: [] };
+        },
+        async submitAnswers() {
+          return { submissionId: 1, overwritten: false, answerCount: 50, submittedAt: new Date().toISOString() };
+        }
+      },
+      likertAssessmentResultService: {
+        async getResult() {
+          return {
+            dimensionScores: { interest: 80, ability: 82, value: 84 },
+            weights: { interest: 0.4 as const, ability: 0.4 as const, value: 0.2 as const },
+            scores: [
+              { direction: "employment" as const, score: 82 },
+              { direction: "postgraduate" as const, score: 81 },
+              { direction: "civil_service" as const, score: 80 }
+            ],
+            recommendation: { direction: "employment" as const, reason: "test" }
+          };
+        }
+      },
+      roleModelMatchingService: {
+        async matchRoleModels() {
+          return { strategy: "score_gap_fallback" as const, matched: [] };
+        }
+      },
+      reportGenerationService: {
+        async generateAllReports() {
+          return {
+            reports: [
+              { direction: "employment" as const, markdown: "# 就业报告" },
+              { direction: "postgraduate" as const, markdown: "# 考研报告" },
+              { direction: "civil_service" as const, markdown: "# 考公报告" }
+            ]
+          };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/student/reports/generate", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.reports.length, 3);
+});


### PR DESCRIPTION
## 变更说明
- 新增三方向报告生成服务（就业/考研/考公）
- 新增接口：POST /student/reports/generate
- 根据测评结果输出 3 份 Markdown 报告
- 补充服务层与路由层测试

## 验证
- pnpm test（103/103 通过）

Closes #18
