### PR TITLE
feat: 实现任务打卡与凭证提交流程

### DIFF
--- a/drizzle/0011_task_check_ins.sql
+++ b/drizzle/0011_task_check_ins.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `task_check_ins` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `task_id` int NOT NULL,
+  `student_id` int NOT NULL,
+  `file_id` varchar(64),
+  `note` varchar(255),
+  `submitted_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `task_check_ins_id` PRIMARY KEY(`id`),
+  CONSTRAINT `task_check_ins_task_student_unique` UNIQUE(`task_id`,`student_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `task_check_ins` ADD CONSTRAINT `task_check_ins_task_id_tasks_id_fk` FOREIGN KEY (`task_id`) REFERENCES `tasks`(`id`) ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE `task_check_ins` ADD CONSTRAINT `task_check_ins_student_id_students_id_fk` FOREIGN KEY (`student_id`) REFERENCES `students`(`id`) ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX `task_check_ins_task_id_idx` ON `task_check_ins` (`task_id`);
+--> statement-breakpoint
+CREATE INDEX `task_check_ins_student_id_idx` ON `task_check_ins` (`student_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1772416719533,
       "tag": "0010_report_generation_jobs",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "5",
+      "when": 1772417310063,
+      "tag": "0011_task_check_ins",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -172,6 +172,28 @@ export const tasks = mysqlTable(
   })
 );
 
+export const taskCheckIns = mysqlTable(
+  "task_check_ins",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    taskId: int("task_id")
+      .notNull()
+      .references(() => tasks.id),
+    studentId: int("student_id")
+      .notNull()
+      .references(() => students.id),
+    fileId: varchar("file_id", { length: 64 }),
+    note: varchar("note", { length: 255 }),
+    submittedAt: timestamp("submitted_at").defaultNow().notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    taskStudentUnique: uniqueIndex("task_check_ins_task_student_unique").on(table.taskId, table.studentId),
+    taskIdIdx: index("task_check_ins_task_id_idx").on(table.taskId),
+    studentIdIdx: index("task_check_ins_student_id_idx").on(table.studentId)
+  })
+);
+
 export const certificates = mysqlTable(
   "certificates",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   reportGenerationJobs,
   reports,
   students,
+  taskCheckIns,
   tasks,
   teacherClassGrants,
   teacherStudentGrants
@@ -51,6 +52,7 @@ import { createLikertAssessmentResultService } from "./modules/assessment/result
 import { createRoleModelMatchingService } from "./modules/role-model/matching.js";
 import { createReportGenerationService } from "./modules/report/generation.js";
 import { createReportJobSyncService } from "./modules/report/job-sync.js";
+import { createTaskCheckInService } from "./modules/task/checkin.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -305,6 +307,76 @@ const reportJobRepo = {
 };
 const reportJobSyncService = createReportJobSyncService({
   reportJobRepo
+});
+
+const taskCheckInRepo = {
+  async findTaskByIdAndStudentId(taskId: number, studentId: number) {
+    const records = await db
+      .select({
+        id: tasks.id,
+        studentId: tasks.studentId
+      })
+      .from(tasks)
+      .where(and(eq(tasks.id, taskId), eq(tasks.studentId, studentId)))
+      .limit(1);
+
+    return records[0] ?? null;
+  },
+  async hasCertificateFileForStudent(studentId: number, fileId: string) {
+    const records = await db
+      .select({
+        id: certificateFiles.id
+      })
+      .from(certificateFiles)
+      .where(and(eq(certificateFiles.studentId, studentId), eq(certificateFiles.fileId, fileId)))
+      .limit(1);
+
+    return records.length > 0;
+  },
+  async upsertTaskCheckIn({ taskId, studentId, fileId, note, submittedAt }: {
+    taskId: number;
+    studentId: number;
+    fileId: string | null;
+    note: string | null;
+    submittedAt: Date;
+  }) {
+    const existing = await db
+      .select({
+        id: taskCheckIns.id
+      })
+      .from(taskCheckIns)
+      .where(and(eq(taskCheckIns.taskId, taskId), eq(taskCheckIns.studentId, studentId)))
+      .limit(1);
+
+    if (existing[0]) {
+      await db
+        .update(taskCheckIns)
+        .set({
+          fileId,
+          note,
+          submittedAt
+        })
+        .where(eq(taskCheckIns.id, existing[0].id));
+      return existing[0].id;
+    }
+
+    const insertResult = await db
+      .insert(taskCheckIns)
+      .values({
+        taskId,
+        studentId,
+        fileId,
+        note,
+        submittedAt,
+        createdAt: submittedAt
+      });
+
+    return Number(insertResult[0].insertId);
+  }
+};
+
+const taskCheckInService = createTaskCheckInService({
+  taskCheckInRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -912,7 +984,8 @@ app.route(
     likertAssessmentResultService,
     roleModelMatchingService,
     reportGenerationService,
-    reportJobSyncService
+    reportJobSyncService,
+    taskCheckInService
   })
 );
 

--- a/src/modules/task/checkin.ts
+++ b/src/modules/task/checkin.ts
@@ -1,0 +1,83 @@
+export interface TaskCheckInRepository {
+  findTaskByIdAndStudentId(taskId: number, studentId: number): Promise<{ id: number; studentId: number } | null>;
+  hasCertificateFileForStudent(studentId: number, fileId: string): Promise<boolean>;
+  upsertTaskCheckIn(input: {
+    taskId: number;
+    studentId: number;
+    fileId: string | null;
+    note: string | null;
+    submittedAt: Date;
+  }): Promise<number>;
+}
+
+export interface SubmitTaskCheckInInput {
+  taskId: number;
+  studentId: number;
+  fileId: string | null;
+  note: string | null;
+}
+
+export interface SubmitTaskCheckInResult {
+  checkInId: number;
+  status: "submitted";
+}
+
+export interface TaskCheckInService {
+  submitTaskCheckIn(input: SubmitTaskCheckInInput): Promise<SubmitTaskCheckInResult>;
+}
+
+export interface CreateTaskCheckInServiceInput {
+  taskCheckInRepo: TaskCheckInRepository;
+}
+
+export class TaskCheckInTaskNotFoundError extends Error {
+  constructor() {
+    super("task not found");
+    this.name = "TaskCheckInTaskNotFoundError";
+  }
+}
+
+export class TaskCheckInCertificateNotFoundError extends Error {
+  constructor() {
+    super("certificate file not found");
+    this.name = "TaskCheckInCertificateNotFoundError";
+  }
+}
+
+export const createTaskCheckInService = ({
+  taskCheckInRepo
+}: CreateTaskCheckInServiceInput): TaskCheckInService => {
+  return {
+    async submitTaskCheckIn({
+      taskId,
+      studentId,
+      fileId,
+      note
+    }: SubmitTaskCheckInInput): Promise<SubmitTaskCheckInResult> {
+      const task = await taskCheckInRepo.findTaskByIdAndStudentId(taskId, studentId);
+      if (!task) {
+        throw new TaskCheckInTaskNotFoundError();
+      }
+
+      if (fileId) {
+        const hasFile = await taskCheckInRepo.hasCertificateFileForStudent(studentId, fileId);
+        if (!hasFile) {
+          throw new TaskCheckInCertificateNotFoundError();
+        }
+      }
+
+      const checkInId = await taskCheckInRepo.upsertTaskCheckIn({
+        taskId,
+        studentId,
+        fileId,
+        note,
+        submittedAt: new Date()
+      });
+
+      return {
+        checkInId,
+        status: "submitted"
+      };
+    }
+  };
+};

--- a/src/routes/student.ts
+++ b/src/routes/student.ts
@@ -21,6 +21,11 @@ import {
 } from "../modules/role-model/matching.js";
 import type { ReportGenerationService } from "../modules/report/generation.js";
 import type { ReportJobSyncService } from "../modules/report/job-sync.js";
+import {
+  TaskCheckInCertificateNotFoundError,
+  TaskCheckInTaskNotFoundError,
+  type TaskCheckInService
+} from "../modules/task/checkin.js";
 
 export interface StudentRouteDependencies {
   requireStudentAuth: MiddlewareHandler;
@@ -30,6 +35,7 @@ export interface StudentRouteDependencies {
   roleModelMatchingService?: Pick<RoleModelMatchingService, "matchRoleModels">;
   reportGenerationService?: Pick<ReportGenerationService, "generateAllReports">;
   reportJobSyncService?: Pick<ReportJobSyncService, "syncGeneratedReports">;
+  taskCheckInService?: Pick<TaskCheckInService, "submitTaskCheckIn">;
 }
 
 const isUploadedFile = (value: unknown): value is UploadedFile => {
@@ -91,6 +97,11 @@ export const createStudentRoutes = ({
   reportJobSyncService = {
     async syncGeneratedReports() {
       throw new Error("reportJobSyncService is not configured");
+    }
+  },
+  taskCheckInService = {
+    async submitTaskCheckIn() {
+      throw new Error("taskCheckInService is not configured");
     }
   }
 }: StudentRouteDependencies) => {
@@ -218,6 +229,49 @@ export const createStudentRoutes = ({
       },
       200
     );
+  });
+
+  student.post("/tasks/:taskId/check-ins", requireStudentAuth, async (c) => {
+    const studentAuth = c.get("studentAuth");
+    if (!studentAuth) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const taskId = Number.parseInt(c.req.param("taskId"), 10);
+    if (!Number.isInteger(taskId) || taskId <= 0) {
+      return c.json({ message: "invalid task id" }, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const fileIdRaw = (body as { fileId?: unknown })?.fileId;
+    const noteRaw = (body as { note?: unknown })?.note;
+    const fileId = typeof fileIdRaw === "string" && fileIdRaw.trim().length > 0 ? fileIdRaw.trim() : null;
+    const note = typeof noteRaw === "string" && noteRaw.trim().length > 0 ? noteRaw.trim() : null;
+
+    try {
+      const result = await taskCheckInService.submitTaskCheckIn({
+        taskId,
+        studentId: studentAuth.studentId,
+        fileId,
+        note
+      });
+
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof TaskCheckInTaskNotFoundError) {
+        return c.json({ message: "task not found" }, 404);
+      }
+      if (error instanceof TaskCheckInCertificateNotFoundError) {
+        return c.json({ message: "certificate file not found" }, 404);
+      }
+      throw error;
+    }
   });
 
   student.post("/certificates/upload", requireStudentAuth, async (c) => {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 10, "journal should contain at least 10 entries");
+  assert.ok(entries.length >= 11, "journal should contain at least 11 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -183,4 +183,18 @@ test("0010 migration file should include report_generation_jobs table", () => {
   assert.match(migrationSql, /`student_no`\s+varchar\(32\)\s+NOT\s+NULL/i);
   assert.match(migrationSql, /`payload_json`\s+text\s+NOT\s+NULL/i);
   assert.match(migrationSql, /`status`\s+varchar\(16\)\s+NOT\s+NULL/i);
+});
+
+test("0011 migration file should include task_check_ins table", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0011 = migrationFiles.find((fileName) => /^0011_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0011, "expected a 0011 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0011), "utf8");
+
+  assert.match(migrationSql, /CREATE TABLE\s+`task_check_ins`/i);
+  assert.match(migrationSql, /`task_id`\s+int\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /`student_id`\s+int\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /UNIQUE\(`task_id`,`student_id`\)/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -17,6 +17,7 @@ import {
   roleScopes,
   roles,
   students,
+  taskCheckIns,
   tasks,
   teacherClassGrants,
   teacherStudentGrants
@@ -115,4 +116,12 @@ test("schema should include report_generation_jobs sync table", () => {
   assert.equal(reportGenerationJobs.studentNo.name, "student_no");
   assert.equal(reportGenerationJobs.payloadJson.name, "payload_json");
   assert.equal(reportGenerationJobs.status.name, "status");
+});
+
+test("schema should include task_check_ins table for check-in flow", () => {
+  assert.equal(taskCheckIns[Symbol.for("drizzle:Name")], "task_check_ins");
+  assert.equal(taskCheckIns.taskId.name, "task_id");
+  assert.equal(taskCheckIns.studentId.name, "student_id");
+  assert.equal(taskCheckIns.fileId.name, "file_id");
+  assert.equal(taskCheckIns.note.name, "note");
 });

--- a/tests/task/checkin.test.ts
+++ b/tests/task/checkin.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createStudentRoutes } from "../../src/routes/student.ts";
+import {
+  createTaskCheckInService,
+  TaskCheckInTaskNotFoundError,
+  type TaskCheckInRepository
+} from "../../src/modules/task/checkin.ts";
+
+const authorizedStudentMiddleware: MiddlewareHandler = async (c, next) => {
+  const authorization = c.req.header("authorization") ?? "";
+  if (authorization !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("studentAuth", {
+    studentId: 1001,
+    studentNo: "S20261001",
+    mustChangePassword: false
+  });
+
+  await next();
+};
+
+test("task check-in service should upsert checkin with certificate file", async () => {
+  let saved = 0;
+
+  const repo: TaskCheckInRepository = {
+    async findTaskByIdAndStudentId() {
+      return { id: 10, studentId: 1001 };
+    },
+    async hasCertificateFileForStudent() {
+      return true;
+    },
+    async upsertTaskCheckIn() {
+      saved += 1;
+      return 1;
+    }
+  };
+
+  const service = createTaskCheckInService({ taskCheckInRepo: repo });
+  const result = await service.submitTaskCheckIn({
+    taskId: 10,
+    studentId: 1001,
+    fileId: "cert_xxx",
+    note: "完成任务"
+  });
+
+  assert.equal(result.checkInId, 1);
+  assert.equal(saved, 1);
+});
+
+test("task check-in service should throw when task not found", async () => {
+  const repo: TaskCheckInRepository = {
+    async findTaskByIdAndStudentId() {
+      return null;
+    },
+    async hasCertificateFileForStudent() {
+      return true;
+    },
+    async upsertTaskCheckIn() {
+      return 1;
+    }
+  };
+
+  const service = createTaskCheckInService({ taskCheckInRepo: repo });
+
+  await assert.rejects(
+    async () => {
+      await service.submitTaskCheckIn({ taskId: 999, studentId: 1001, fileId: null, note: null });
+    },
+    (error: unknown) => error instanceof TaskCheckInTaskNotFoundError
+  );
+});
+
+test("POST /student/tasks/:taskId/check-ins should return checkInId", async () => {
+  const app = new Hono();
+  app.route(
+    "/student",
+    createStudentRoutes({
+      requireStudentAuth: authorizedStudentMiddleware,
+      certificateUploadService: {
+        async uploadCertificate() {
+          throw new Error("not implemented");
+        }
+      },
+      likertAssessmentService: {
+        async getQuestions() {
+          return { version: "v1" as const, scaleMin: 1 as const, scaleMax: 5 as const, questions: [] };
+        },
+        async submitAnswers() {
+          return { submissionId: 1, overwritten: false, answerCount: 50, submittedAt: new Date().toISOString() };
+        }
+      },
+      likertAssessmentResultService: {
+        async getResult() {
+          return {
+            dimensionScores: { interest: 80, ability: 82, value: 84 },
+            weights: { interest: 0.4 as const, ability: 0.4 as const, value: 0.2 as const },
+            scores: [
+              { direction: "employment" as const, score: 82 },
+              { direction: "postgraduate" as const, score: 81 },
+              { direction: "civil_service" as const, score: 80 }
+            ],
+            recommendation: { direction: "employment" as const, reason: "test" }
+          };
+        }
+      },
+      roleModelMatchingService: {
+        async matchRoleModels() {
+          return { strategy: "score_gap_fallback" as const, matched: [] };
+        }
+      },
+      reportGenerationService: {
+        async generateAllReports() {
+          return { reports: [] };
+        }
+      },
+      reportJobSyncService: {
+        async syncGeneratedReports() {
+          return { jobId: 1, status: "done" as const };
+        }
+      },
+      taskCheckInService: {
+        async submitTaskCheckIn() {
+          return { checkInId: 77, status: "submitted" as const };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/student/tasks/10/check-ins", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      fileId: "cert_xxx",
+      note: "完成任务"
+    })
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.checkInId, 77);
+});


### PR DESCRIPTION
## 变更说明
- 新增 task_check_ins 表与 0011 迁移
- 新增任务打卡服务：校验任务归属、校验凭证文件归属、打卡记录 upsert
- 新增接口：POST /student/tasks/:taskId/check-ins
- 支持提交 fileId 与 note，返回 checkInId/status
- 补充服务层、路由层、迁移与 schema 测试

## 验证
- pnpm test（112/112 通过）

Closes #20
