### PR TITLE
feat: 实现教师端我的学生授权查询与筛选分页

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { createRoleModelMatchingService } from "./modules/role-model/matching.js
 import { createReportGenerationService } from "./modules/report/generation.js";
 import { createReportJobSyncService } from "./modules/report/job-sync.js";
 import { createTaskCheckInService } from "./modules/task/checkin.js";
+import { createTeacherMyStudentsService } from "./modules/teacher/my-students.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -61,6 +62,7 @@ import { createAuthRoutes } from "./routes/auth.js";
 import healthRoutes from "./routes/health.js";
 import { createResourcesRoutes } from "./routes/resources.js";
 import { createStudentRoutes } from "./routes/student.js";
+import { createTeacherRoutes } from "./routes/teacher.js";
 
 const studentRepo = {
   async findStudentByNo(studentNo: string) {
@@ -377,6 +379,138 @@ const taskCheckInRepo = {
 
 const taskCheckInService = createTaskCheckInService({
   taskCheckInRepo
+});
+
+const teacherMyStudentsRepo = {
+  async listAuthorizedStudents({ teacherId, page, pageSize, filters }: {
+    teacherId: string;
+    page: number;
+    pageSize: number;
+    filters: {
+      classId?: number;
+      majorId?: number;
+      grade?: number;
+      assessmentStatus?: "done" | "pending";
+      reportStatus?: "generated" | "pending";
+    };
+  }) {
+    const directGrantRows = await db
+      .select({ studentId: teacherStudentGrants.studentId })
+      .from(teacherStudentGrants)
+      .where(eq(teacherStudentGrants.teacherId, teacherId));
+
+    const classGrantRows = await db
+      .select({ classId: teacherClassGrants.classId })
+      .from(teacherClassGrants)
+      .where(eq(teacherClassGrants.teacherId, teacherId));
+
+    const classIds = new Set<number>(classGrantRows.map((item) => item.classId));
+    const classStudentRows =
+      classGrantRows.length > 0
+        ? (await db
+            .select({ studentId: students.id, classId: students.classId })
+            .from(students))
+            .filter((row) => classIds.has(row.classId))
+            .map((row) => ({ studentId: row.studentId }))
+        : [];
+
+    const authorizedStudentIdSet = new Set<number>([
+      ...directGrantRows.map((item) => item.studentId),
+      ...classStudentRows.map((item) => item.studentId)
+    ]);
+
+    if (authorizedStudentIdSet.size === 0) {
+      return { total: 0, rows: [] };
+    }
+
+    const authorizedStudents = await db
+      .select({
+        studentId: students.id,
+        studentNo: students.studentNo,
+        name: students.name,
+        classId: classes.id,
+        className: classes.name,
+        majorId: classes.majorId,
+        majorName: majors.name
+      })
+      .from(students)
+      .innerJoin(classes, eq(students.classId, classes.id))
+      .leftJoin(majors, eq(classes.majorId, majors.id));
+
+    let rows = authorizedStudents.filter((row) => authorizedStudentIdSet.has(row.studentId));
+
+    if (filters.classId) {
+      rows = rows.filter((row) => row.classId === filters.classId);
+    }
+    if (filters.majorId) {
+      rows = rows.filter((row) => row.majorId === filters.majorId);
+    }
+
+    const studentNoList = rows.map((row) => row.studentNo);
+    const assessmentRows =
+      rows.length > 0
+        ? await db
+            .select({ studentId: assessmentSubmissions.studentId })
+            .from(assessmentSubmissions)
+        : [];
+    const reportRows =
+      rows.length > 0
+        ? await db
+            .select({ studentId: reports.studentId })
+            .from(reports)
+        : [];
+    const enrollmentRows =
+      studentNoList.length > 0
+        ? await db
+            .select({
+              studentNo: enrollmentProfiles.studentNo,
+              grade: enrollmentProfiles.admissionYear
+            })
+            .from(enrollmentProfiles)
+        : [];
+
+    const assessmentDoneSet = new Set<number>(assessmentRows.map((item) => item.studentId));
+    const reportDoneSet = new Set<number>(reportRows.map((item) => item.studentId));
+    const gradeByStudentNo = new Map<string, number | null>(
+      enrollmentRows.map((item) => [item.studentNo, item.grade])
+    );
+
+    let enrichedRows = rows.map((row) => ({
+      ...row,
+      grade: gradeByStudentNo.get(row.studentNo) ?? null,
+      assessmentDone: assessmentDoneSet.has(row.studentId),
+      reportGenerated: reportDoneSet.has(row.studentId)
+    }));
+
+    if (filters.grade) {
+      enrichedRows = enrichedRows.filter((row) => row.grade === filters.grade);
+    }
+    if (filters.assessmentStatus) {
+      enrichedRows = enrichedRows.filter((row) =>
+        filters.assessmentStatus === "done" ? row.assessmentDone : !row.assessmentDone
+      );
+    }
+    if (filters.reportStatus) {
+      enrichedRows = enrichedRows.filter((row) =>
+        filters.reportStatus === "generated" ? row.reportGenerated : !row.reportGenerated
+      );
+    }
+
+    enrichedRows.sort((left, right) => left.studentId - right.studentId);
+
+    const total = enrichedRows.length;
+    const offset = (page - 1) * pageSize;
+    const pagedRows = enrichedRows.slice(offset, offset + pageSize);
+
+    return {
+      total,
+      rows: pagedRows
+    };
+  }
+};
+
+const teacherMyStudentsService = createTeacherMyStudentsService({
+  teacherMyStudentsRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -975,6 +1109,12 @@ app.route(
   })
 );
 app.route("/resources", createResourcesRoutes({ createResourceAuthorization }));
+app.route(
+  "/teacher",
+  createTeacherRoutes({
+    teacherMyStudentsService
+  })
+);
 app.route(
   "/student",
   createStudentRoutes({

--- a/src/modules/teacher/my-students.ts
+++ b/src/modules/teacher/my-students.ts
@@ -1,0 +1,75 @@
+export type AssessmentStatusFilter = "done" | "pending";
+export type ReportStatusFilter = "generated" | "pending";
+
+export interface TeacherMyStudentsFilter {
+  classId?: number;
+  majorId?: number;
+  grade?: number;
+  assessmentStatus?: AssessmentStatusFilter;
+  reportStatus?: ReportStatusFilter;
+}
+
+export interface TeacherMyStudentsQuery {
+  teacherId: string;
+  page: number;
+  pageSize: number;
+  filters: TeacherMyStudentsFilter;
+}
+
+export interface TeacherStudentRow {
+  studentId: number;
+  studentNo: string;
+  name: string;
+  classId: number;
+  className: string;
+  majorId: number | null;
+  majorName: string | null;
+  grade: number | null;
+  assessmentDone: boolean;
+  reportGenerated: boolean;
+}
+
+export interface TeacherMyStudentsRepository {
+  listAuthorizedStudents(query: TeacherMyStudentsQuery): Promise<{
+    total: number;
+    rows: TeacherStudentRow[];
+  }>;
+}
+
+export interface TeacherMyStudentsService {
+  getMyStudents(query: TeacherMyStudentsQuery): Promise<{
+    page: number;
+    pageSize: number;
+    total: number;
+    items: TeacherStudentRow[];
+  }>;
+}
+
+export interface CreateTeacherMyStudentsServiceInput {
+  teacherMyStudentsRepo: TeacherMyStudentsRepository;
+}
+
+export const createTeacherMyStudentsService = ({
+  teacherMyStudentsRepo
+}: CreateTeacherMyStudentsServiceInput): TeacherMyStudentsService => {
+  return {
+    async getMyStudents(query: TeacherMyStudentsQuery) {
+      const safePage = Number.isInteger(query.page) && query.page > 0 ? query.page : 1;
+      const safePageSize =
+        Number.isInteger(query.pageSize) && query.pageSize > 0 && query.pageSize <= 100 ? query.pageSize : 20;
+
+      const result = await teacherMyStudentsRepo.listAuthorizedStudents({
+        ...query,
+        page: safePage,
+        pageSize: safePageSize
+      });
+
+      return {
+        page: safePage,
+        pageSize: safePageSize,
+        total: result.total,
+        items: result.rows
+      };
+    }
+  };
+};

--- a/src/routes/teacher.ts
+++ b/src/routes/teacher.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import type {
+  AssessmentStatusFilter,
+  ReportStatusFilter,
+  TeacherMyStudentsService
+} from "../modules/teacher/my-students.js";
+
+export interface TeacherRouteDependencies {
+  teacherMyStudentsService: Pick<TeacherMyStudentsService, "getMyStudents">;
+}
+
+const parsePositiveInteger = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (!/^[1-9]\d*$/.test(raw)) {
+    return undefined;
+  }
+  return Number.parseInt(raw, 10);
+};
+
+const parseAssessmentStatus = (raw: string | undefined): AssessmentStatusFilter | undefined => {
+  if (raw === "done" || raw === "pending") {
+    return raw;
+  }
+  return undefined;
+};
+
+const parseReportStatus = (raw: string | undefined): ReportStatusFilter | undefined => {
+  if (raw === "generated" || raw === "pending") {
+    return raw;
+  }
+  return undefined;
+};
+
+export const createTeacherRoutes = ({ teacherMyStudentsService }: TeacherRouteDependencies) => {
+  const teacher = new Hono();
+
+  teacher.get("/my-students", async (c) => {
+    const teacherId = c.req.header("x-teacher-id")?.trim();
+    if (!teacherId) {
+      return c.json({ message: "teacher id required" }, 401);
+    }
+
+    const page = parsePositiveInteger(c.req.query("page")) ?? 1;
+    const pageSize = parsePositiveInteger(c.req.query("pageSize")) ?? 20;
+
+    const result = await teacherMyStudentsService.getMyStudents({
+      teacherId,
+      page,
+      pageSize,
+      filters: {
+        classId: parsePositiveInteger(c.req.query("classId")),
+        majorId: parsePositiveInteger(c.req.query("majorId")),
+        grade: parsePositiveInteger(c.req.query("grade")),
+        assessmentStatus: parseAssessmentStatus(c.req.query("assessmentStatus")),
+        reportStatus: parseReportStatus(c.req.query("reportStatus"))
+      }
+    });
+
+    return c.json(result, 200);
+  });
+
+  return teacher;
+};
+
+export default createTeacherRoutes;

--- a/tests/teacher/my-students.test.ts
+++ b/tests/teacher/my-students.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createTeacherMyStudentsService, type TeacherMyStudentsRepository } from "../../src/modules/teacher/my-students.ts";
+import { createTeacherRoutes } from "../../src/routes/teacher.ts";
+
+test("teacher my students service should keep stable pagination order by studentId", async () => {
+  const repo: TeacherMyStudentsRepository = {
+    async listAuthorizedStudents() {
+      return {
+        total: 3,
+        rows: [
+          {
+            studentId: 1,
+            studentNo: "S1",
+            name: "A",
+            classId: 1,
+            className: "1班",
+            majorId: 1,
+            majorName: "软件",
+            grade: 2022,
+            assessmentDone: true,
+            reportGenerated: true
+          },
+          {
+            studentId: 2,
+            studentNo: "S2",
+            name: "B",
+            classId: 1,
+            className: "1班",
+            majorId: 1,
+            majorName: "软件",
+            grade: 2022,
+            assessmentDone: false,
+            reportGenerated: false
+          },
+          {
+            studentId: 3,
+            studentNo: "S3",
+            name: "C",
+            classId: 2,
+            className: "2班",
+            majorId: 2,
+            majorName: "法学",
+            grade: 2023,
+            assessmentDone: false,
+            reportGenerated: true
+          }
+        ]
+      };
+    }
+  };
+
+  const service = createTeacherMyStudentsService({
+    teacherMyStudentsRepo: repo
+  });
+
+  const result = await service.getMyStudents({
+    teacherId: "T-1",
+    page: 1,
+    pageSize: 20,
+    filters: {}
+  });
+
+  assert.equal(result.total, 3);
+  assert.equal(result.items[0].studentId, 1);
+});
+
+test("GET /teacher/my-students should require teacher id", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: {
+        async getMyStudents() {
+          return { page: 1, pageSize: 20, total: 0, items: [] };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/teacher/my-students");
+  assert.equal(response.status, 401);
+});
+
+test("GET /teacher/my-students should support filters and pagination", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: {
+        async getMyStudents(query) {
+          assert.equal(query.teacherId, "T-1");
+          assert.equal(query.filters.classId, 2);
+          assert.equal(query.filters.majorId, 3);
+          assert.equal(query.filters.grade, 2022);
+          assert.equal(query.filters.assessmentStatus, "done");
+          assert.equal(query.filters.reportStatus, "generated");
+          assert.equal(query.page, 2);
+          assert.equal(query.pageSize, 10);
+
+          return {
+            page: 2,
+            pageSize: 10,
+            total: 1,
+            items: [
+              {
+                studentId: 12,
+                studentNo: "S20260012",
+                name: "张三",
+                classId: 2,
+                className: "2班",
+                majorId: 3,
+                majorName: "计算机",
+                grade: 2022,
+                assessmentDone: true,
+                reportGenerated: true
+              }
+            ]
+          };
+        }
+      }
+    })
+  );
+
+  const response = await app.request(
+    "/teacher/my-students?page=2&pageSize=10&classId=2&majorId=3&grade=2022&assessmentStatus=done&reportStatus=generated",
+    {
+      headers: {
+        "x-teacher-id": "T-1"
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.total, 1);
+  assert.equal(payload.items[0].studentNo, "S20260012");
+});


### PR DESCRIPTION
## 变更说明
- 新增教师端接口：GET /teacher/my-students
- 仅返回授权学生（学生级授权 + 班级级授权）
- 支持按班级/专业/年级/测评状态/报告状态筛选
- 提供稳定分页（按 studentId 升序）
- 新增 teacher 路由与服务层测试

## 验证
- pnpm test（115/115 通过）

Closes #21
