### PR TITLE
feat: 实现教师学生详情聚合接口（含授权校验）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,7 @@ import { createReportGenerationService } from "./modules/report/generation.js";
 import { createReportJobSyncService } from "./modules/report/job-sync.js";
 import { createTaskCheckInService } from "./modules/task/checkin.js";
 import { createTeacherMyStudentsService } from "./modules/teacher/my-students.js";
+import { createTeacherStudentDetailService } from "./modules/teacher/student-detail.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
 import { createExcelImportValidationService } from "./modules/import/excel-validation.js";
 import { createCertificateUploadService } from "./modules/upload/certificate-upload.js";
@@ -511,6 +512,84 @@ const teacherMyStudentsRepo = {
 
 const teacherMyStudentsService = createTeacherMyStudentsService({
   teacherMyStudentsRepo
+});
+
+const teacherStudentDetailRepo = {
+  async isStudentAuthorized(teacherId: string, studentId: number) {
+    const direct = await db
+      .select({ id: teacherStudentGrants.id })
+      .from(teacherStudentGrants)
+      .where(and(eq(teacherStudentGrants.teacherId, teacherId), eq(teacherStudentGrants.studentId, studentId)))
+      .limit(1);
+    if (direct.length > 0) {
+      return true;
+    }
+
+    const studentRow = await db
+      .select({ classId: students.classId })
+      .from(students)
+      .where(eq(students.id, studentId))
+      .limit(1);
+    if (!studentRow[0]) {
+      return false;
+    }
+
+    const classGrant = await db
+      .select({ id: teacherClassGrants.id })
+      .from(teacherClassGrants)
+      .where(and(eq(teacherClassGrants.teacherId, teacherId), eq(teacherClassGrants.classId, studentRow[0].classId)))
+      .limit(1);
+    return classGrant.length > 0;
+  },
+  async getStudentProfile(studentId: number) {
+    const rows = await db
+      .select({
+        studentId: students.id,
+        studentNo: students.studentNo,
+        name: students.name
+      })
+      .from(students)
+      .where(eq(students.id, studentId))
+      .limit(1);
+    return rows[0] ?? null;
+  },
+  async getAssessmentSummary(studentId: number) {
+    const rows = await db
+      .select({ id: assessmentSubmissions.id })
+      .from(assessmentSubmissions)
+      .where(eq(assessmentSubmissions.studentId, studentId))
+      .limit(1);
+    return { done: rows.length > 0 };
+  },
+  async getReportSummary(studentId: number) {
+    const rows = await db
+      .select({ id: reports.id })
+      .from(reports)
+      .where(eq(reports.studentId, studentId));
+    return { count: rows.length };
+  },
+  async getTaskSummary(studentId: number) {
+    const rows = await db
+      .select({ id: tasks.id })
+      .from(tasks)
+      .where(eq(tasks.studentId, studentId));
+    return { count: rows.length };
+  },
+  async listCertificateFiles(studentId: number) {
+    return db
+      .select({
+        fileId: certificateFiles.fileId,
+        originalName: certificateFiles.originalName,
+        mimeType: certificateFiles.mimeType,
+        sizeBytes: certificateFiles.sizeBytes
+      })
+      .from(certificateFiles)
+      .where(eq(certificateFiles.studentId, studentId));
+  }
+};
+
+const teacherStudentDetailService = createTeacherStudentDetailService({
+  teacherStudentDetailRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -1112,7 +1191,8 @@ app.route("/resources", createResourcesRoutes({ createResourceAuthorization }));
 app.route(
   "/teacher",
   createTeacherRoutes({
-    teacherMyStudentsService
+    teacherMyStudentsService,
+    teacherStudentDetailService
   })
 );
 app.route(

--- a/src/modules/teacher/student-detail.ts
+++ b/src/modules/teacher/student-detail.ts
@@ -1,0 +1,85 @@
+export interface TeacherStudentDetailRepository {
+  isStudentAuthorized(teacherId: string, studentId: number): Promise<boolean>;
+  getStudentProfile(studentId: number): Promise<{
+    studentId: number;
+    studentNo: string;
+    name: string;
+  } | null>;
+  getAssessmentSummary(studentId: number): Promise<{ done: boolean }>;
+  getReportSummary(studentId: number): Promise<{ count: number }>;
+  getTaskSummary(studentId: number): Promise<{ count: number }>;
+  listCertificateFiles(studentId: number): Promise<
+    Array<{
+      fileId: string;
+      originalName: string;
+      mimeType: string;
+      sizeBytes: number;
+    }>
+  >;
+}
+
+export interface TeacherStudentDetailService {
+  getStudentDetail(input: { teacherId: string; studentId: number }): Promise<{
+    profile: { studentId: number; studentNo: string; name: string };
+    assessment: { done: boolean };
+    report: { count: number };
+    task: { count: number };
+    certificateFiles: Array<{
+      fileId: string;
+      originalName: string;
+      mimeType: string;
+      sizeBytes: number;
+    }>;
+  }>;
+}
+
+export interface CreateTeacherStudentDetailServiceInput {
+  teacherStudentDetailRepo: TeacherStudentDetailRepository;
+}
+
+export class TeacherStudentDetailForbiddenError extends Error {
+  constructor() {
+    super("forbidden");
+    this.name = "TeacherStudentDetailForbiddenError";
+  }
+}
+
+export class TeacherStudentDetailNotFoundError extends Error {
+  constructor() {
+    super("student not found");
+    this.name = "TeacherStudentDetailNotFoundError";
+  }
+}
+
+export const createTeacherStudentDetailService = ({
+  teacherStudentDetailRepo
+}: CreateTeacherStudentDetailServiceInput): TeacherStudentDetailService => {
+  return {
+    async getStudentDetail({ teacherId, studentId }) {
+      const authorized = await teacherStudentDetailRepo.isStudentAuthorized(teacherId, studentId);
+      if (!authorized) {
+        throw new TeacherStudentDetailForbiddenError();
+      }
+
+      const profile = await teacherStudentDetailRepo.getStudentProfile(studentId);
+      if (!profile) {
+        throw new TeacherStudentDetailNotFoundError();
+      }
+
+      const [assessment, report, task, certificateFiles] = await Promise.all([
+        teacherStudentDetailRepo.getAssessmentSummary(studentId),
+        teacherStudentDetailRepo.getReportSummary(studentId),
+        teacherStudentDetailRepo.getTaskSummary(studentId),
+        teacherStudentDetailRepo.listCertificateFiles(studentId)
+      ]);
+
+      return {
+        profile,
+        assessment,
+        report,
+        task,
+        certificateFiles
+      };
+    }
+  };
+};

--- a/src/routes/teacher.ts
+++ b/src/routes/teacher.ts
@@ -4,9 +4,15 @@ import type {
   ReportStatusFilter,
   TeacherMyStudentsService
 } from "../modules/teacher/my-students.js";
+import {
+  TeacherStudentDetailForbiddenError,
+  TeacherStudentDetailNotFoundError,
+  type TeacherStudentDetailService
+} from "../modules/teacher/student-detail.js";
 
 export interface TeacherRouteDependencies {
   teacherMyStudentsService: Pick<TeacherMyStudentsService, "getMyStudents">;
+  teacherStudentDetailService?: Pick<TeacherStudentDetailService, "getStudentDetail">;
 }
 
 const parsePositiveInteger = (raw: string | undefined): number | undefined => {
@@ -33,7 +39,14 @@ const parseReportStatus = (raw: string | undefined): ReportStatusFilter | undefi
   return undefined;
 };
 
-export const createTeacherRoutes = ({ teacherMyStudentsService }: TeacherRouteDependencies) => {
+export const createTeacherRoutes = ({
+  teacherMyStudentsService,
+  teacherStudentDetailService = {
+    async getStudentDetail() {
+      throw new Error("teacherStudentDetailService is not configured");
+    }
+  }
+}: TeacherRouteDependencies) => {
   const teacher = new Hono();
 
   teacher.get("/my-students", async (c) => {
@@ -59,6 +72,34 @@ export const createTeacherRoutes = ({ teacherMyStudentsService }: TeacherRouteDe
     });
 
     return c.json(result, 200);
+  });
+
+  teacher.get("/students/:id/detail", async (c) => {
+    const teacherId = c.req.header("x-teacher-id")?.trim();
+    if (!teacherId) {
+      return c.json({ message: "teacher id required" }, 401);
+    }
+
+    const studentId = Number.parseInt(c.req.param("id"), 10);
+    if (!Number.isInteger(studentId) || studentId <= 0) {
+      return c.json({ message: "invalid student id" }, 400);
+    }
+
+    try {
+      const result = await teacherStudentDetailService.getStudentDetail({
+        teacherId,
+        studentId
+      });
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof TeacherStudentDetailForbiddenError) {
+        return c.json({ message: "forbidden" }, 403);
+      }
+      if (error instanceof TeacherStudentDetailNotFoundError) {
+        return c.json({ message: "student not found" }, 404);
+      }
+      throw error;
+    }
   });
 
   return teacher;

--- a/tests/teacher/student-detail.test.ts
+++ b/tests/teacher/student-detail.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import {
+  TeacherStudentDetailForbiddenError,
+  createTeacherStudentDetailService,
+  type TeacherStudentDetailRepository
+} from "../../src/modules/teacher/student-detail.ts";
+import { createTeacherRoutes } from "../../src/routes/teacher.ts";
+
+test("teacher student detail service should aggregate profile/assessment/report/task/certificate", async () => {
+  const repo: TeacherStudentDetailRepository = {
+    async isStudentAuthorized() {
+      return true;
+    },
+    async getStudentProfile() {
+      return { studentId: 1, studentNo: "S1", name: "张三" };
+    },
+    async getAssessmentSummary() {
+      return { done: true };
+    },
+    async getReportSummary() {
+      return { count: 2 };
+    },
+    async getTaskSummary() {
+      return { count: 3 };
+    },
+    async listCertificateFiles() {
+      return [{ fileId: "f1", originalName: "a.pdf", mimeType: "application/pdf", sizeBytes: 1024 }];
+    }
+  };
+
+  const service = createTeacherStudentDetailService({
+    teacherStudentDetailRepo: repo
+  });
+
+  const result = await service.getStudentDetail({
+    teacherId: "T-1",
+    studentId: 1
+  });
+
+  assert.equal(result.profile.studentNo, "S1");
+  assert.equal(result.report.count, 2);
+  assert.equal(result.task.count, 3);
+  assert.equal(result.certificateFiles.length, 1);
+});
+
+test("teacher student detail service should reject unauthorized student", async () => {
+  const repo: TeacherStudentDetailRepository = {
+    async isStudentAuthorized() {
+      return false;
+    },
+    async getStudentProfile() {
+      return { studentId: 1, studentNo: "S1", name: "张三" };
+    },
+    async getAssessmentSummary() {
+      return { done: true };
+    },
+    async getReportSummary() {
+      return { count: 0 };
+    },
+    async getTaskSummary() {
+      return { count: 0 };
+    },
+    async listCertificateFiles() {
+      return [];
+    }
+  };
+
+  const service = createTeacherStudentDetailService({
+    teacherStudentDetailRepo: repo
+  });
+
+  await assert.rejects(
+    async () => {
+      await service.getStudentDetail({ teacherId: "T-1", studentId: 1 });
+    },
+    (error: unknown) => error instanceof TeacherStudentDetailForbiddenError
+  );
+});
+
+test("GET /teacher/students/:id/detail should return 403 when unauthorized", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: {
+        async getMyStudents() {
+          return { page: 1, pageSize: 20, total: 0, items: [] };
+        }
+      },
+      teacherStudentDetailService: {
+        async getStudentDetail() {
+          throw new TeacherStudentDetailForbiddenError();
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/teacher/students/1/detail", {
+    headers: { "x-teacher-id": "T-1" }
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("GET /teacher/students/:id/detail should return aggregated detail", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: {
+        async getMyStudents() {
+          return { page: 1, pageSize: 20, total: 0, items: [] };
+        }
+      },
+      teacherStudentDetailService: {
+        async getStudentDetail() {
+          return {
+            profile: { studentId: 1, studentNo: "S1", name: "张三" },
+            assessment: { done: true },
+            report: { count: 2 },
+            task: { count: 3 },
+            certificateFiles: [{ fileId: "f1", originalName: "a.pdf", mimeType: "application/pdf", sizeBytes: 1 }]
+          };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/teacher/students/1/detail", {
+    headers: { "x-teacher-id": "T-1" }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.profile.studentNo, "S1");
+  assert.equal(payload.certificateFiles.length, 1);
+});


### PR DESCRIPTION
## 变更说明
- 新增教师学生详情接口：GET /teacher/students/:id/detail
- 聚合返回：画像/测评/报告/任务/凭证元数据
- 增加授权校验：仅授权学生可见（未授权返回 403）
- 新增服务层和路由层测试

## 验证
- pnpm test（119/119 通过）

Closes #22
