### PR TITLE
feat: 实现教师侧活动执行接口（分组/签到/结果登记）

### DIFF
--- a/drizzle/0012_teacher_activity_execution.sql
+++ b/drizzle/0012_teacher_activity_execution.sql
@@ -1,0 +1,26 @@
+CREATE TABLE `teacher_activity_assignments` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `activity_id` int NOT NULL,
+  `teacher_id` varchar(64) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `teacher_activity_assignments_id` PRIMARY KEY(`id`),
+  CONSTRAINT `teacher_activity_assignments_activity_teacher_unique` UNIQUE(`activity_id`,`teacher_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `teacher_activity_assignments` ADD CONSTRAINT `teacher_activity_assignments_activity_id_activities_id_fk` FOREIGN KEY (`activity_id`) REFERENCES `activities`(`id`) ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX `teacher_activity_assignments_teacher_id_idx` ON `teacher_activity_assignments` (`teacher_id`);
+--> statement-breakpoint
+CREATE TABLE `activity_execution_records` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `activity_id` int NOT NULL,
+  `teacher_id` varchar(64) NOT NULL,
+  `payload_json` text NOT NULL,
+  `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `activity_execution_records_id` PRIMARY KEY(`id`),
+  CONSTRAINT `activity_execution_records_activity_teacher_unique` UNIQUE(`activity_id`,`teacher_id`)
+);
+--> statement-breakpoint
+ALTER TABLE `activity_execution_records` ADD CONSTRAINT `activity_execution_records_activity_id_activities_id_fk` FOREIGN KEY (`activity_id`) REFERENCES `activities`(`id`) ON DELETE no action ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX `activity_execution_records_teacher_id_idx` ON `activity_execution_records` (`teacher_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1772417310063,
       "tag": "0011_task_check_ins",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "5",
+      "when": 1772418082248,
+      "tag": "0012_teacher_activity_execution",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -296,6 +296,45 @@ export const activities = mysqlTable(
   })
 );
 
+export const teacherActivityAssignments = mysqlTable(
+  "teacher_activity_assignments",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    activityId: int("activity_id")
+      .notNull()
+      .references(() => activities.id),
+    teacherId: varchar("teacher_id", { length: 64 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    activityTeacherUnique: uniqueIndex("teacher_activity_assignments_activity_teacher_unique").on(
+      table.activityId,
+      table.teacherId
+    ),
+    teacherIdIdx: index("teacher_activity_assignments_teacher_id_idx").on(table.teacherId)
+  })
+);
+
+export const activityExecutionRecords = mysqlTable(
+  "activity_execution_records",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    activityId: int("activity_id")
+      .notNull()
+      .references(() => activities.id),
+    teacherId: varchar("teacher_id", { length: 64 }).notNull(),
+    payloadJson: text("payload_json").notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull()
+  },
+  (table) => ({
+    activityTeacherUnique: uniqueIndex("activity_execution_records_activity_teacher_unique").on(
+      table.activityId,
+      table.teacherId
+    ),
+    teacherIdIdx: index("activity_execution_records_teacher_id_idx").on(table.teacherId)
+  })
+);
+
 export const auditLogs = mysqlTable(
   "audit_logs",
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { env } from "./config/env.js";
 import { db } from "./db/client.js";
 import {
   assessmentSubmissions,
+  activityExecutionRecords,
   activities,
   auditLogs,
   certificateFiles,
@@ -20,6 +21,7 @@ import {
   students,
   taskCheckIns,
   tasks,
+  teacherActivityAssignments,
   teacherClassGrants,
   teacherStudentGrants
 } from "./db/schema.js";
@@ -53,6 +55,7 @@ import { createRoleModelMatchingService } from "./modules/role-model/matching.js
 import { createReportGenerationService } from "./modules/report/generation.js";
 import { createReportJobSyncService } from "./modules/report/job-sync.js";
 import { createTaskCheckInService } from "./modules/task/checkin.js";
+import { createTeacherActivityExecutionService } from "./modules/teacher/activity-execution.js";
 import { createTeacherMyStudentsService } from "./modules/teacher/my-students.js";
 import { createTeacherStudentDetailService } from "./modules/teacher/student-detail.js";
 import { createEnrollmentProfileService } from "./modules/enrollment/profile.js";
@@ -590,6 +593,59 @@ const teacherStudentDetailRepo = {
 
 const teacherStudentDetailService = createTeacherStudentDetailService({
   teacherStudentDetailRepo
+});
+
+const teacherActivityExecutionRepo = {
+  async isTeacherAssigned(teacherId: string, activityId: number) {
+    const rows = await db
+      .select({ id: teacherActivityAssignments.id })
+      .from(teacherActivityAssignments)
+      .where(
+        and(
+          eq(teacherActivityAssignments.teacherId, teacherId),
+          eq(teacherActivityAssignments.activityId, activityId)
+        )
+      )
+      .limit(1);
+    return rows.length > 0;
+  },
+  async upsertExecutionRecord({ teacherId, activityId, payloadJson, updatedAt }: {
+    teacherId: string;
+    activityId: number;
+    payloadJson: string;
+    updatedAt: Date;
+  }) {
+    const existing = await db
+      .select({ id: activityExecutionRecords.id })
+      .from(activityExecutionRecords)
+      .where(
+        and(eq(activityExecutionRecords.teacherId, teacherId), eq(activityExecutionRecords.activityId, activityId))
+      )
+      .limit(1);
+
+    if (existing[0]) {
+      await db
+        .update(activityExecutionRecords)
+        .set({
+          payloadJson,
+          updatedAt
+        })
+        .where(eq(activityExecutionRecords.id, existing[0].id));
+      return existing[0].id;
+    }
+
+    const inserted = await db.insert(activityExecutionRecords).values({
+      teacherId,
+      activityId,
+      payloadJson,
+      updatedAt
+    });
+    return Number(inserted[0].insertId);
+  }
+};
+
+const teacherActivityExecutionService = createTeacherActivityExecutionService({
+  teacherActivityExecutionRepo
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -1192,7 +1248,8 @@ app.route(
   "/teacher",
   createTeacherRoutes({
     teacherMyStudentsService,
-    teacherStudentDetailService
+    teacherStudentDetailService,
+    teacherActivityExecutionService
   })
 );
 app.route(

--- a/src/modules/teacher/activity-execution.ts
+++ b/src/modules/teacher/activity-execution.ts
@@ -1,0 +1,56 @@
+export interface TeacherActivityExecutionRepository {
+  isTeacherAssigned(teacherId: string, activityId: number): Promise<boolean>;
+  upsertExecutionRecord(input: {
+    teacherId: string;
+    activityId: number;
+    payloadJson: string;
+    updatedAt: Date;
+  }): Promise<number>;
+}
+
+export interface TeacherActivityExecutionService {
+  executeActivity(input: {
+    teacherId: string;
+    activityId: number;
+    payload: unknown;
+  }): Promise<{
+    recordId: number;
+    status: "submitted";
+  }>;
+}
+
+export interface CreateTeacherActivityExecutionServiceInput {
+  teacherActivityExecutionRepo: TeacherActivityExecutionRepository;
+}
+
+export class TeacherActivityForbiddenError extends Error {
+  constructor() {
+    super("forbidden");
+    this.name = "TeacherActivityForbiddenError";
+  }
+}
+
+export const createTeacherActivityExecutionService = ({
+  teacherActivityExecutionRepo
+}: CreateTeacherActivityExecutionServiceInput): TeacherActivityExecutionService => {
+  return {
+    async executeActivity({ teacherId, activityId, payload }) {
+      const assigned = await teacherActivityExecutionRepo.isTeacherAssigned(teacherId, activityId);
+      if (!assigned) {
+        throw new TeacherActivityForbiddenError();
+      }
+
+      const recordId = await teacherActivityExecutionRepo.upsertExecutionRecord({
+        teacherId,
+        activityId,
+        payloadJson: JSON.stringify(payload ?? {}),
+        updatedAt: new Date()
+      });
+
+      return {
+        recordId,
+        status: "submitted"
+      };
+    }
+  };
+};

--- a/src/routes/teacher.ts
+++ b/src/routes/teacher.ts
@@ -9,10 +9,15 @@ import {
   TeacherStudentDetailNotFoundError,
   type TeacherStudentDetailService
 } from "../modules/teacher/student-detail.js";
+import {
+  TeacherActivityForbiddenError,
+  type TeacherActivityExecutionService
+} from "../modules/teacher/activity-execution.js";
 
 export interface TeacherRouteDependencies {
   teacherMyStudentsService: Pick<TeacherMyStudentsService, "getMyStudents">;
   teacherStudentDetailService?: Pick<TeacherStudentDetailService, "getStudentDetail">;
+  teacherActivityExecutionService?: Pick<TeacherActivityExecutionService, "executeActivity">;
 }
 
 const parsePositiveInteger = (raw: string | undefined): number | undefined => {
@@ -44,6 +49,11 @@ export const createTeacherRoutes = ({
   teacherStudentDetailService = {
     async getStudentDetail() {
       throw new Error("teacherStudentDetailService is not configured");
+    }
+  },
+  teacherActivityExecutionService = {
+    async executeActivity() {
+      throw new Error("teacherActivityExecutionService is not configured");
     }
   }
 }: TeacherRouteDependencies) => {
@@ -97,6 +107,39 @@ export const createTeacherRoutes = ({
       }
       if (error instanceof TeacherStudentDetailNotFoundError) {
         return c.json({ message: "student not found" }, 404);
+      }
+      throw error;
+    }
+  });
+
+  teacher.post("/activities/:id/execute", async (c) => {
+    const teacherId = c.req.header("x-teacher-id")?.trim();
+    if (!teacherId) {
+      return c.json({ message: "teacher id required" }, 401);
+    }
+
+    const activityId = Number.parseInt(c.req.param("id"), 10);
+    if (!Number.isInteger(activityId) || activityId <= 0) {
+      return c.json({ message: "invalid activity id" }, 400);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    try {
+      const result = await teacherActivityExecutionService.executeActivity({
+        teacherId,
+        activityId,
+        payload
+      });
+      return c.json(result, 200);
+    } catch (error) {
+      if (error instanceof TeacherActivityForbiddenError) {
+        return c.json({ message: "forbidden" }, 403);
       }
       throw error;
     }

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 11, "journal should contain at least 11 entries");
+  assert.ok(entries.length >= 12, "journal should contain at least 12 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -197,4 +197,17 @@ test("0011 migration file should include task_check_ins table", () => {
   assert.match(migrationSql, /`task_id`\s+int\s+NOT\s+NULL/i);
   assert.match(migrationSql, /`student_id`\s+int\s+NOT\s+NULL/i);
   assert.match(migrationSql, /UNIQUE\(`task_id`,`student_id`\)/i);
+});
+
+test("0012 migration file should include teacher activity assignment and execution tables", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0012 = migrationFiles.find((fileName) => /^0012_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0012, "expected a 0012 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0012), "utf8");
+
+  assert.match(migrationSql, /CREATE TABLE\s+`teacher_activity_assignments`/i);
+  assert.match(migrationSql, /CREATE TABLE\s+`activity_execution_records`/i);
+  assert.match(migrationSql, /`payload_json`\s+text\s+NOT\s+NULL/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   assessmentSubmissions,
+  activityExecutionRecords,
   activities,
   authScopes,
   auditLogs,
@@ -19,6 +20,7 @@ import {
   students,
   taskCheckIns,
   tasks,
+  teacherActivityAssignments,
   teacherClassGrants,
   teacherStudentGrants
 } from "../../src/db/schema.ts";
@@ -124,4 +126,11 @@ test("schema should include task_check_ins table for check-in flow", () => {
   assert.equal(taskCheckIns.studentId.name, "student_id");
   assert.equal(taskCheckIns.fileId.name, "file_id");
   assert.equal(taskCheckIns.note.name, "note");
+});
+
+test("schema should include teacher activity execution tables", () => {
+  assert.equal(teacherActivityAssignments[Symbol.for("drizzle:Name")], "teacher_activity_assignments");
+  assert.equal(activityExecutionRecords[Symbol.for("drizzle:Name")], "activity_execution_records");
+  assert.equal(teacherActivityAssignments.activityId.name, "activity_id");
+  assert.equal(activityExecutionRecords.payloadJson.name, "payload_json");
 });

--- a/tests/teacher/activity-execution.test.ts
+++ b/tests/teacher/activity-execution.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import {
+  TeacherActivityForbiddenError,
+  createTeacherActivityExecutionService,
+  type TeacherActivityExecutionRepository
+} from "../../src/modules/teacher/activity-execution.ts";
+import { createTeacherRoutes } from "../../src/routes/teacher.ts";
+
+test("teacher activity execution service should upsert execution payload", async () => {
+  let saved = 0;
+  const repo: TeacherActivityExecutionRepository = {
+    async isTeacherAssigned() {
+      return true;
+    },
+    async upsertExecutionRecord() {
+      saved += 1;
+      return 1;
+    }
+  };
+
+  const service = createTeacherActivityExecutionService({
+    teacherActivityExecutionRepo: repo
+  });
+
+  const result = await service.executeActivity({
+    teacherId: "T-1",
+    activityId: 10,
+    payload: {
+      groupings: [{ groupName: "A组", studentNos: ["S1"] }],
+      signInMaterials: ["签到表"],
+      result: { award: "一等奖" }
+    }
+  });
+
+  assert.equal(result.recordId, 1);
+  assert.equal(saved, 1);
+});
+
+test("teacher activity execution service should throw forbidden when teacher not assigned", async () => {
+  const repo: TeacherActivityExecutionRepository = {
+    async isTeacherAssigned() {
+      return false;
+    },
+    async upsertExecutionRecord() {
+      return 1;
+    }
+  };
+
+  const service = createTeacherActivityExecutionService({
+    teacherActivityExecutionRepo: repo
+  });
+
+  await assert.rejects(
+    async () => {
+      await service.executeActivity({ teacherId: "T-1", activityId: 10, payload: {} });
+    },
+    (error: unknown) => error instanceof TeacherActivityForbiddenError
+  );
+});
+
+test("POST /teacher/activities/:id/execute should return 403 when teacher not assigned", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: { async getMyStudents() { return { page: 1, pageSize: 20, total: 0, items: [] }; } },
+      teacherStudentDetailService: { async getStudentDetail() { throw new Error("not implemented"); } },
+      teacherActivityExecutionService: {
+        async executeActivity() {
+          throw new TeacherActivityForbiddenError();
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/teacher/activities/10/execute", {
+    method: "POST",
+    headers: { "x-teacher-id": "T-1", "content-type": "application/json" },
+    body: JSON.stringify({ result: { score: 95 } })
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("POST /teacher/activities/:id/execute should return submitted record id", async () => {
+  const app = new Hono();
+  app.route(
+    "/teacher",
+    createTeacherRoutes({
+      teacherMyStudentsService: { async getMyStudents() { return { page: 1, pageSize: 20, total: 0, items: [] }; } },
+      teacherStudentDetailService: { async getStudentDetail() { throw new Error("not implemented"); } },
+      teacherActivityExecutionService: {
+        async executeActivity() {
+          return { recordId: 9, status: "submitted" as const };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/teacher/activities/10/execute", {
+    method: "POST",
+    headers: { "x-teacher-id": "T-1", "content-type": "application/json" },
+    body: JSON.stringify({ result: { score: 95 } })
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.recordId, 9);
+});


### PR DESCRIPTION
## 变更说明
- 新增教师活动执行能力：分组/签到材料/结果登记统一 payload
- 新增接口：POST /teacher/activities/:id/execute
- 未指派教师调用返回 403
- 新增 teacher_activity_assignments / activity_execution_records 表与 0012 迁移
- 补充服务层、路由层、迁移与 schema 测试

## 验证
- pnpm test（125/125 通过）

Closes #23
