### PR TITLE
feat: 实现管理员组织结构与教师账号管理接口

### DIFF
--- a/drizzle/0013_teachers.sql
+++ b/drizzle/0013_teachers.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `teachers` (
+  `id` int AUTO_INCREMENT NOT NULL,
+  `teacher_id` varchar(64) NOT NULL,
+  `name` varchar(64) NOT NULL,
+  `account` varchar(64) NOT NULL,
+  `password_hash` varchar(255) NOT NULL,
+  `status` varchar(16) NOT NULL DEFAULT 'active',
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT `teachers_id` PRIMARY KEY(`id`),
+  CONSTRAINT `teachers_teacher_id_unique` UNIQUE(`teacher_id`),
+  CONSTRAINT `teachers_account_unique` UNIQUE(`account`)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1772418082248,
       "tag": "0012_teacher_activity_execution",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "5",
+      "when": 1772418261374,
+      "tag": "0013_teachers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -407,3 +407,20 @@ export const roleScopes = mysqlTable(
     scopeIdIdx: index("role_scopes_scope_id_idx").on(table.scopeId)
   })
 );
+
+export const teachers = mysqlTable(
+  "teachers",
+  {
+    id: int("id").autoincrement().primaryKey(),
+    teacherId: varchar("teacher_id", { length: 64 }).notNull(),
+    name: varchar("name", { length: 64 }).notNull(),
+    account: varchar("account", { length: 64 }).notNull(),
+    passwordHash: varchar("password_hash", { length: 255 }).notNull(),
+    status: varchar("status", { length: 16 }).notNull().default("active"),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  (table) => ({
+    teacherIdUnique: uniqueIndex("teachers_teacher_id_unique").on(table.teacherId),
+    accountUnique: uniqueIndex("teachers_account_unique").on(table.account)
+  })
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   students,
   taskCheckIns,
   tasks,
+  teachers,
   teacherActivityAssignments,
   teacherClassGrants,
   teacherStudentGrants
@@ -828,6 +829,60 @@ const auditLogService = createAuditLogService({
   auditLogRepo
 });
 
+const adminOrgService = {
+  async createCollege({ schoolId, name }: { schoolId: number; name: string }) {
+    const inserted = await db
+      .insert(colleges)
+      .values({
+        schoolId,
+        name
+      });
+    return { collegeId: Number(inserted[0].insertId) };
+  },
+  async updateCollege({ collegeId, name }: { collegeId: number; name: string }) {
+    await db
+      .update(colleges)
+      .set({ name })
+      .where(eq(colleges.id, collegeId));
+  },
+  async deleteCollege({ collegeId }: { collegeId: number }) {
+    await db.delete(colleges).where(eq(colleges.id, collegeId));
+  }
+};
+
+const teacherAccountService = {
+  async createTeacherAccount({ name, account, password, status }: {
+    name: string;
+    account: string;
+    password: string;
+    status: "active" | "frozen";
+  }) {
+    const teacherId = `T-${Date.now()}`;
+    const passwordHash = await bcryptPasswordHasher.hash(password);
+    await db.insert(teachers).values({
+      teacherId,
+      name,
+      account,
+      passwordHash,
+      status
+    });
+    return { teacherId };
+  },
+  async updateTeacherStatus({ teacherId, status }: { teacherId: string; status: "active" | "frozen" }) {
+    await db
+      .update(teachers)
+      .set({ status })
+      .where(eq(teachers.teacherId, teacherId));
+  },
+  async resetTeacherPassword({ teacherId, newPassword }: { teacherId: string; newPassword: string }) {
+    const passwordHash = await bcryptPasswordHasher.hash(newPassword);
+    await db
+      .update(teachers)
+      .set({ passwordHash })
+      .where(eq(teachers.teacherId, teacherId));
+  }
+};
+
 const excelImportValidationService = createExcelImportValidationService();
 const dashboardSlowQueryObserver = createDashboardSlowQueryObserver({
   slowQueryThresholdMs: env.METRICS_SLOW_QUERY_THRESHOLD_MS
@@ -1240,6 +1295,8 @@ app.route(
     excelImportValidationService,
     dashboardDimensionAggregationService,
     dashboardTrendFunnelService,
+    adminOrgService,
+    teacherAccountService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -39,6 +39,26 @@ interface AdminPublishActivityRequestBody {
   title: string;
 }
 
+interface AdminCollegeCreateBody {
+  schoolId: number;
+  name: string;
+}
+
+interface AdminCollegeUpdateBody {
+  name: string;
+}
+
+interface AdminTeacherCreateBody {
+  name: string;
+  account: string;
+  password: string;
+  status: "active" | "frozen";
+}
+
+interface AdminTeacherStatusBody {
+  status: "active" | "frozen";
+}
+
 export interface AdminRouteDependencies {
   studentAuthService: Pick<StudentAuthService, "resetStudentPasswordByAdmin">;
   authorizationGrantService: Pick<AuthorizationGrantService, "assignGrant" | "revokeGrant">;
@@ -53,6 +73,21 @@ export interface AdminRouteDependencies {
     "aggregateByDimension"
   >;
   dashboardTrendFunnelService?: Pick<DashboardTrendFunnelService, "getTrendAndFunnel">;
+  adminOrgService?: {
+    createCollege(input: { schoolId: number; name: string }): Promise<{ collegeId: number }>;
+    updateCollege(input: { collegeId: number; name: string }): Promise<void>;
+    deleteCollege(input: { collegeId: number }): Promise<void>;
+  };
+  teacherAccountService?: {
+    createTeacherAccount(input: {
+      name: string;
+      account: string;
+      password: string;
+      status: "active" | "frozen";
+    }): Promise<{ teacherId: string }>;
+    updateTeacherStatus(input: { teacherId: string; status: "active" | "frozen" }): Promise<void>;
+    resetTeacherPassword(input: { teacherId: string; newPassword: string }): Promise<void>;
+  };
   adminApiKey: string;
 }
 
@@ -232,6 +267,30 @@ const defaultDashboardTrendFunnelService: Pick<DashboardTrendFunnelService, "get
   }
 };
 
+const defaultAdminOrgService: NonNullable<AdminRouteDependencies["adminOrgService"]> = {
+  async createCollege() {
+    throw new Error("adminOrgService is not configured");
+  },
+  async updateCollege() {
+    throw new Error("adminOrgService is not configured");
+  },
+  async deleteCollege() {
+    throw new Error("adminOrgService is not configured");
+  }
+};
+
+const defaultTeacherAccountService: NonNullable<AdminRouteDependencies["teacherAccountService"]> = {
+  async createTeacherAccount() {
+    throw new Error("teacherAccountService is not configured");
+  },
+  async updateTeacherStatus() {
+    throw new Error("teacherAccountService is not configured");
+  },
+  async resetTeacherPassword() {
+    throw new Error("teacherAccountService is not configured");
+  }
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
   authorizationGrantService,
@@ -240,6 +299,8 @@ export const createAdminRoutes = ({
   excelImportValidationService = defaultExcelImportValidationService,
   dashboardDimensionAggregationService = defaultDashboardDimensionAggregationService,
   dashboardTrendFunnelService = defaultDashboardTrendFunnelService,
+  adminOrgService = defaultAdminOrgService,
+  teacherAccountService = defaultTeacherAccountService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
@@ -292,6 +353,130 @@ export const createAdminRoutes = ({
 
       throw error;
     }
+  });
+
+  admin.post("/org/colleges", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as AdminCollegeCreateBody | null;
+    if (!body || !Number.isInteger(body.schoolId) || body.schoolId <= 0 || !body.name?.trim()) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const result = await adminOrgService.createCollege({
+      schoolId: body.schoolId,
+      name: body.name.trim()
+    });
+    return c.json(result, 200);
+  });
+
+  admin.patch("/org/colleges/:id", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const collegeId = parsePositiveInteger(c.req.param("id"));
+    const body = (await c.req.json().catch(() => null)) as AdminCollegeUpdateBody | null;
+    if (!collegeId || !body?.name?.trim()) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    await adminOrgService.updateCollege({ collegeId, name: body.name.trim() });
+    return c.json({ message: "ok" }, 200);
+  });
+
+  admin.delete("/org/colleges/:id", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const collegeId = parsePositiveInteger(c.req.param("id"));
+    if (!collegeId) {
+      return c.json({ message: "invalid college id" }, 400);
+    }
+
+    await adminOrgService.deleteCollege({ collegeId });
+    return c.json({ message: "ok" }, 200);
+  });
+
+  admin.post("/teachers", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as AdminTeacherCreateBody | null;
+    if (
+      !body ||
+      !body.name?.trim() ||
+      !body.account?.trim() ||
+      !body.password ||
+      (body.status !== "active" && body.status !== "frozen")
+    ) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const result = await teacherAccountService.createTeacherAccount({
+      name: body.name.trim(),
+      account: body.account.trim(),
+      password: body.password,
+      status: body.status
+    });
+    await auditLogService.logActivityPublish({
+      operator: resolveOperator(c.req.header("x-admin-operator-id")),
+      activityType: "course",
+      title: `teacher_create:${result.teacherId}`
+    });
+    return c.json(result, 200);
+  });
+
+  admin.patch("/teachers/:id/status", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const teacherId = c.req.param("id");
+    const body = (await c.req.json().catch(() => null)) as AdminTeacherStatusBody | null;
+    if (!teacherId?.trim() || !body || (body.status !== "active" && body.status !== "frozen")) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    await teacherAccountService.updateTeacherStatus({
+      teacherId: teacherId.trim(),
+      status: body.status
+    });
+    await auditLogService.logActivityPublish({
+      operator: resolveOperator(c.req.header("x-admin-operator-id")),
+      activityType: "course",
+      title: `teacher_status:${teacherId}:${body.status}`
+    });
+    return c.json({ message: "ok" }, 200);
+  });
+
+  admin.post("/teachers/:id/reset-password", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const teacherId = c.req.param("id")?.trim();
+    const body = (await c.req.json().catch(() => null)) as { newPassword?: string } | null;
+    if (!teacherId || !body?.newPassword || body.newPassword.length < 8) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    await teacherAccountService.resetTeacherPassword({
+      teacherId,
+      newPassword: body.newPassword
+    });
+    await auditLogService.logPasswordReset({
+      operator: resolveOperator(c.req.header("x-admin-operator-id")),
+      targetStudentId: 0
+    });
+    return c.json({ message: "ok" }, 200);
   });
 
   admin.post("/authorizations/grants", async (c) => {

--- a/tests/admin/org-teacher-account.test.ts
+++ b/tests/admin/org-teacher-account.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+
+const baseDependencies = {
+  studentAuthService: {
+    async resetStudentPasswordByAdmin() {
+      return;
+    }
+  },
+  authorizationGrantService: {
+    async assignGrant() {
+      return;
+    },
+    async revokeGrant() {
+      return;
+    }
+  },
+  activityService: {
+    async publishActivity() {
+      return;
+    }
+  },
+  auditLogService: {
+    async logAuthorizationGrant() {
+      return;
+    },
+    async logAuthorizationRevoke() {
+      return;
+    },
+    async logPasswordReset() {
+      return;
+    },
+    async logActivityPublish() {
+      return;
+    }
+  },
+  adminApiKey: "admin-key"
+} as const;
+
+test("admin org CRUD should require admin key", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      ...baseDependencies,
+      adminOrgService: {
+        async createCollege() {
+          return { collegeId: 1 };
+        },
+        async updateCollege() {
+          return;
+        },
+        async deleteCollege() {
+          return;
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/admin/org/colleges", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schoolId: 1, name: "计算机学院" })
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("admin should create college and teacher account", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      ...baseDependencies,
+      adminOrgService: {
+        async createCollege() {
+          return { collegeId: 2 };
+        },
+        async updateCollege() {
+          return;
+        },
+        async deleteCollege() {
+          return;
+        }
+      },
+      teacherAccountService: {
+        async createTeacherAccount() {
+          return { teacherId: "T-1001" };
+        },
+        async updateTeacherStatus() {
+          return;
+        },
+        async resetTeacherPassword() {
+          return;
+        }
+      }
+    })
+  );
+
+  const collegeResp = await app.request("/admin/org/colleges", {
+    method: "POST",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ schoolId: 1, name: "计算机学院" })
+  });
+  assert.equal(collegeResp.status, 200);
+  assert.equal((await collegeResp.json()).collegeId, 2);
+
+  const teacherResp = await app.request("/admin/teachers", {
+    method: "POST",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ name: "李老师", account: "t_li", password: "Passw0rd!", status: "active" })
+  });
+  assert.equal(teacherResp.status, 200);
+  assert.equal((await teacherResp.json()).teacherId, "T-1001");
+});
+
+test("admin should freeze teacher account and reset password", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      ...baseDependencies,
+      teacherAccountService: {
+        async createTeacherAccount() {
+          return { teacherId: "T-1001" };
+        },
+        async updateTeacherStatus() {
+          return;
+        },
+        async resetTeacherPassword() {
+          return;
+        }
+      }
+    })
+  );
+
+  const freezeResp = await app.request("/admin/teachers/T-1001/status", {
+    method: "PATCH",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ status: "frozen" })
+  });
+  assert.equal(freezeResp.status, 200);
+
+  const resetResp = await app.request("/admin/teachers/T-1001/reset-password", {
+    method: "POST",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ newPassword: "NewPassw0rd!" })
+  });
+  assert.equal(resetResp.status, 200);
+});

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 12, "journal should contain at least 12 entries");
+  assert.ok(entries.length >= 13, "journal should contain at least 13 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011", "0012"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -210,4 +210,16 @@ test("0012 migration file should include teacher activity assignment and executi
   assert.match(migrationSql, /CREATE TABLE\s+`teacher_activity_assignments`/i);
   assert.match(migrationSql, /CREATE TABLE\s+`activity_execution_records`/i);
   assert.match(migrationSql, /`payload_json`\s+text\s+NOT\s+NULL/i);
+});
+
+test("0013 migration file should include teachers table", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0013 = migrationFiles.find((fileName) => /^0013_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0013, "expected a 0013 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0013), "utf8");
+  assert.match(migrationSql, /CREATE TABLE\s+`teachers`/i);
+  assert.match(migrationSql, /`account`\s+varchar\(64\)\s+NOT\s+NULL/i);
+  assert.match(migrationSql, /UNIQUE\(`teacher_id`\)/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -20,6 +20,7 @@ import {
   students,
   taskCheckIns,
   tasks,
+  teachers,
   teacherActivityAssignments,
   teacherClassGrants,
   teacherStudentGrants
@@ -133,4 +134,11 @@ test("schema should include teacher activity execution tables", () => {
   assert.equal(activityExecutionRecords[Symbol.for("drizzle:Name")], "activity_execution_records");
   assert.equal(teacherActivityAssignments.activityId.name, "activity_id");
   assert.equal(activityExecutionRecords.payloadJson.name, "payload_json");
+});
+
+test("schema should include teachers account table", () => {
+  assert.equal(teachers[Symbol.for("drizzle:Name")], "teachers");
+  assert.equal(teachers.teacherId.name, "teacher_id");
+  assert.equal(teachers.account.name, "account");
+  assert.equal(teachers.status.name, "status");
 });


### PR DESCRIPTION
## 变更说明
- 新增管理员组织结构接口（院系节点 CRUD）
- 新增教师账号管理接口（开通/冻结/重置密码）
- 新增 teachers 表与 0013 迁移
- 关键操作写入审计日志
- 补充路由、迁移、schema 测试

## 验证
- pnpm test（130/130 通过）

Closes #24
