### PR TITLE
feat: 实现学生档案CRUD与招生关联校验接口

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -883,6 +883,84 @@ const teacherAccountService = {
   }
 };
 
+const adminStudentArchiveService = {
+  async createStudentArchive({ classId, studentNo, name }: { classId: number; studentNo: string; name: string }) {
+    const inserted = await db
+      .insert(students)
+      .values({
+        classId,
+        studentNo,
+        name,
+        mustChangePassword: true
+      });
+    return { studentId: Number(inserted[0].insertId) };
+  },
+  async getStudentArchive({ studentId }: { studentId: number }) {
+    const rows = await db
+      .select({
+        studentId: students.id,
+        studentNo: students.studentNo,
+        name: students.name,
+        classId: students.classId
+      })
+      .from(students)
+      .where(eq(students.id, studentId))
+      .limit(1);
+    return rows[0] ?? null;
+  },
+  async updateStudentArchive({ studentId, name, classId }: { studentId: number; name?: string; classId?: number }) {
+    const patch: { name?: string; classId?: number } = {};
+    if (name) {
+      patch.name = name;
+    }
+    if (classId) {
+      patch.classId = classId;
+    }
+    if (Object.keys(patch).length === 0) {
+      return;
+    }
+    await db
+      .update(students)
+      .set(patch)
+      .where(eq(students.id, studentId));
+  },
+  async deleteStudentArchive({ studentId }: { studentId: number }) {
+    await db.delete(students).where(eq(students.id, studentId));
+  },
+  async getEnrollmentLinkStatus({ studentId }: { studentId: number }) {
+    const studentRows = await db
+      .select({
+        studentNo: students.studentNo
+      })
+      .from(students)
+      .where(eq(students.id, studentId))
+      .limit(1);
+    const studentNo = studentRows[0]?.studentNo;
+    if (!studentNo) {
+      return { status: "missing" as const, reason: "student not found" };
+    }
+
+    if (!/^S\d{6,}$/.test(studentNo)) {
+      return { status: "abnormal" as const, reason: "abnormal student_no format" };
+    }
+
+    const linkedRows = await db
+      .select({
+        id: enrollmentProfiles.id
+      })
+      .from(enrollmentProfiles)
+      .where(eq(enrollmentProfiles.studentNo, studentNo));
+
+    if (linkedRows.length === 0) {
+      return { status: "missing" as const, reason: "missing in enrollment source" };
+    }
+    if (linkedRows.length > 1) {
+      return { status: "duplicate" as const, reason: "duplicate student_no in enrollment source" };
+    }
+    return { status: "linked" as const, reason: null };
+  }
+};
+
 const excelImportValidationService = createExcelImportValidationService();
 const dashboardSlowQueryObserver = createDashboardSlowQueryObserver({
   slowQueryThresholdMs: env.METRICS_SLOW_QUERY_THRESHOLD_MS
@@ -1297,6 +1375,7 @@ app.route(
     dashboardTrendFunnelService,
     adminOrgService,
     teacherAccountService,
+    adminStudentArchiveService,
     adminApiKey: env.ADMIN_API_KEY
   })
 );

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -59,6 +59,12 @@ interface AdminTeacherStatusBody {
   status: "active" | "frozen";
 }
 
+interface AdminStudentArchiveCreateBody {
+  classId: number;
+  studentNo: string;
+  name: string;
+}
+
 export interface AdminRouteDependencies {
   studentAuthService: Pick<StudentAuthService, "resetStudentPasswordByAdmin">;
   authorizationGrantService: Pick<AuthorizationGrantService, "assignGrant" | "revokeGrant">;
@@ -87,6 +93,21 @@ export interface AdminRouteDependencies {
     }): Promise<{ teacherId: string }>;
     updateTeacherStatus(input: { teacherId: string; status: "active" | "frozen" }): Promise<void>;
     resetTeacherPassword(input: { teacherId: string; newPassword: string }): Promise<void>;
+  };
+  adminStudentArchiveService?: {
+    createStudentArchive(input: { classId: number; studentNo: string; name: string }): Promise<{ studentId: number }>;
+    getStudentArchive(input: { studentId: number }): Promise<{
+      studentId: number;
+      studentNo: string;
+      name: string;
+      classId: number;
+    } | null>;
+    updateStudentArchive(input: { studentId: number; name?: string; classId?: number }): Promise<void>;
+    deleteStudentArchive(input: { studentId: number }): Promise<void>;
+    getEnrollmentLinkStatus(input: { studentId: number }): Promise<{
+      status: "linked" | "missing" | "duplicate" | "abnormal";
+      reason: string | null;
+    }>;
   };
   adminApiKey: string;
 }
@@ -291,6 +312,24 @@ const defaultTeacherAccountService: NonNullable<AdminRouteDependencies["teacherA
   }
 };
 
+const defaultAdminStudentArchiveService: NonNullable<AdminRouteDependencies["adminStudentArchiveService"]> = {
+  async createStudentArchive() {
+    throw new Error("adminStudentArchiveService is not configured");
+  },
+  async getStudentArchive() {
+    throw new Error("adminStudentArchiveService is not configured");
+  },
+  async updateStudentArchive() {
+    throw new Error("adminStudentArchiveService is not configured");
+  },
+  async deleteStudentArchive() {
+    throw new Error("adminStudentArchiveService is not configured");
+  },
+  async getEnrollmentLinkStatus() {
+    throw new Error("adminStudentArchiveService is not configured");
+  }
+};
+
 export const createAdminRoutes = ({
   studentAuthService,
   authorizationGrantService,
@@ -301,6 +340,7 @@ export const createAdminRoutes = ({
   dashboardTrendFunnelService = defaultDashboardTrendFunnelService,
   adminOrgService = defaultAdminOrgService,
   teacherAccountService = defaultTeacherAccountService,
+  adminStudentArchiveService = defaultAdminStudentArchiveService,
   adminApiKey
 }: AdminRouteDependencies) => {
   const admin = new Hono();
@@ -477,6 +517,93 @@ export const createAdminRoutes = ({
       targetStudentId: 0
     });
     return c.json({ message: "ok" }, 200);
+  });
+
+  admin.post("/students", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const body = (await c.req.json().catch(() => null)) as AdminStudentArchiveCreateBody | null;
+    if (
+      !body ||
+      !Number.isInteger(body.classId) ||
+      body.classId <= 0 ||
+      !body.studentNo?.trim() ||
+      !body.name?.trim()
+    ) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    const result = await adminStudentArchiveService.createStudentArchive({
+      classId: body.classId,
+      studentNo: body.studentNo.trim(),
+      name: body.name.trim()
+    });
+    return c.json(result, 200);
+  });
+
+  admin.get("/students/:id", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const studentId = parsePositiveInteger(c.req.param("id"));
+    if (!studentId) {
+      return c.json({ message: "invalid student id" }, 400);
+    }
+    const result = await adminStudentArchiveService.getStudentArchive({ studentId });
+    if (!result) {
+      return c.json({ message: "student not found" }, 404);
+    }
+    return c.json(result, 200);
+  });
+
+  admin.patch("/students/:id", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const studentId = parsePositiveInteger(c.req.param("id"));
+    if (!studentId) {
+      return c.json({ message: "invalid student id" }, 400);
+    }
+    const body = (await c.req.json().catch(() => null)) as { name?: string; classId?: number } | null;
+    if (!body) {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+    await adminStudentArchiveService.updateStudentArchive({
+      studentId,
+      name: typeof body.name === "string" ? body.name.trim() : undefined,
+      classId: Number.isInteger(body.classId) && body.classId > 0 ? body.classId : undefined
+    });
+    return c.json({ message: "ok" }, 200);
+  });
+
+  admin.delete("/students/:id", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const studentId = parsePositiveInteger(c.req.param("id"));
+    if (!studentId) {
+      return c.json({ message: "invalid student id" }, 400);
+    }
+    await adminStudentArchiveService.deleteStudentArchive({ studentId });
+    return c.json({ message: "ok" }, 200);
+  });
+
+  admin.get("/students/:id/enrollment-link", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    const studentId = parsePositiveInteger(c.req.param("id"));
+    if (!studentId) {
+      return c.json({ message: "invalid student id" }, 400);
+    }
+    const result = await adminStudentArchiveService.getEnrollmentLinkStatus({ studentId });
+    return c.json(result, 200);
   });
 
   admin.post("/authorizations/grants", async (c) => {

--- a/tests/admin/student-archive.test.ts
+++ b/tests/admin/student-archive.test.ts
@@ -1,0 +1,126 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+
+const baseDependencies = {
+  studentAuthService: {
+    async resetStudentPasswordByAdmin() {
+      return;
+    }
+  },
+  authorizationGrantService: {
+    async assignGrant() {
+      return;
+    },
+    async revokeGrant() {
+      return;
+    }
+  },
+  activityService: {
+    async publishActivity() {
+      return;
+    }
+  },
+  auditLogService: {
+    async logAuthorizationGrant() {},
+    async logAuthorizationRevoke() {},
+    async logPasswordReset() {},
+    async logActivityPublish() {}
+  },
+  adminApiKey: "admin-key"
+} as const;
+
+test("admin student archive CRUD should work", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      ...baseDependencies,
+      adminStudentArchiveService: {
+        async createStudentArchive() {
+          return { studentId: 101 };
+        },
+        async getStudentArchive() {
+          return { studentId: 101, studentNo: "S20260001", name: "张三", classId: 1 };
+        },
+        async updateStudentArchive() {
+          return;
+        },
+        async deleteStudentArchive() {
+          return;
+        },
+        async getEnrollmentLinkStatus() {
+          return { status: "linked" as const, reason: null };
+        }
+      }
+    })
+  );
+
+  const createResp = await app.request("/admin/students", {
+    method: "POST",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ classId: 1, studentNo: "S20260001", name: "张三" })
+  });
+  assert.equal(createResp.status, 200);
+  assert.equal((await createResp.json()).studentId, 101);
+
+  const detailResp = await app.request("/admin/students/101", {
+    headers: { "x-admin-key": "admin-key" }
+  });
+  assert.equal(detailResp.status, 200);
+
+  const updateResp = await app.request("/admin/students/101", {
+    method: "PATCH",
+    headers: { "x-admin-key": "admin-key", "content-type": "application/json" },
+    body: JSON.stringify({ name: "李四" })
+  });
+  assert.equal(updateResp.status, 200);
+
+  const linkResp = await app.request("/admin/students/101/enrollment-link", {
+    headers: { "x-admin-key": "admin-key" }
+  });
+  assert.equal(linkResp.status, 200);
+  assert.equal((await linkResp.json()).status, "linked");
+
+  const deleteResp = await app.request("/admin/students/101", {
+    method: "DELETE",
+    headers: { "x-admin-key": "admin-key" }
+  });
+  assert.equal(deleteResp.status, 200);
+});
+
+test("admin student archive should return validation errors for duplicate/missing/abnormal studentNo", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      ...baseDependencies,
+      adminStudentArchiveService: {
+        async createStudentArchive() {
+          return { studentId: 1 };
+        },
+        async getStudentArchive() {
+          return { studentId: 1, studentNo: "S1", name: "张三", classId: 1 };
+        },
+        async updateStudentArchive() {
+          return;
+        },
+        async deleteStudentArchive() {
+          return;
+        },
+        async getEnrollmentLinkStatus() {
+          return { status: "duplicate" as const, reason: "duplicate student_no in enrollment source" };
+        }
+      }
+    })
+  );
+
+  const response = await app.request("/admin/students/1/enrollment-link", {
+    headers: { "x-admin-key": "admin-key" }
+  });
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.status, "duplicate");
+  assert.ok(payload.reason.includes("duplicate"));
+});


### PR DESCRIPTION
## 变更说明
- 新增学生档案接口：POST/GET/PATCH/DELETE /admin/students
- 新增招生关联校验接口：GET /admin/students/:id/enrollment-link
- 支持关联状态：linked / missing / duplicate / abnormal
- 可提示缺失/重复/异常学号
- 补充 admin 路由测试

## 验证
- pnpm test（132/132 通过）

Closes #25
