### PR TITLE
feat: 实现授权中心批量授权与读写级别能力

### DIFF
--- a/drizzle/0014_grant_access_level.sql
+++ b/drizzle/0014_grant_access_level.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `teacher_student_grants`
+  ADD `access_level` enum('read','manage') NOT NULL DEFAULT 'read';
+
+ALTER TABLE `teacher_class_grants`
+  ADD `access_level` enum('read','manage') NOT NULL DEFAULT 'read';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1772418261374,
       "tag": "0013_teachers",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "5",
+      "when": 1772419007433,
+      "tag": "0014_grant_access_level",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -251,6 +251,7 @@ export const teacherStudentGrants = mysqlTable(
     studentId: int("student_id")
       .notNull()
       .references(() => students.id),
+    accessLevel: mysqlEnum("access_level", ["read", "manage"]).notNull().default("read"),
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({
@@ -271,6 +272,7 @@ export const teacherClassGrants = mysqlTable(
     classId: int("class_id")
       .notNull()
       .references(() => classes.id),
+    accessLevel: mysqlEnum("access_level", ["read", "manage"]).notNull().default("read"),
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -734,20 +734,19 @@ const resourceAuthorizationService = createResourceAuthorizationService({
 });
 
 const authorizationGrantRepo = {
-  async assignStudentGrant(teacherId: string, studentId: number): Promise<void> {
-    const existing = await db
-      .select({ id: teacherStudentGrants.id })
-      .from(teacherStudentGrants)
-      .where(and(eq(teacherStudentGrants.teacherId, teacherId), eq(teacherStudentGrants.studentId, studentId)))
-      .limit(1);
-
-    if (existing.length > 0) {
-      return;
-    }
-
+  async assignStudentGrant(
+    teacherId: string,
+    studentId: number,
+    accessLevel: "read" | "manage"
+  ): Promise<void> {
     await db.insert(teacherStudentGrants).values({
       teacherId,
-      studentId
+      studentId,
+      accessLevel
+    }).onDuplicateKeyUpdate({
+      set: {
+        accessLevel
+      }
     });
   },
   async revokeStudentGrant(teacherId: string, studentId: number): Promise<void> {
@@ -755,20 +754,19 @@ const authorizationGrantRepo = {
       .delete(teacherStudentGrants)
       .where(and(eq(teacherStudentGrants.teacherId, teacherId), eq(teacherStudentGrants.studentId, studentId)));
   },
-  async assignClassGrant(teacherId: string, classId: number): Promise<void> {
-    const existing = await db
-      .select({ id: teacherClassGrants.id })
-      .from(teacherClassGrants)
-      .where(and(eq(teacherClassGrants.teacherId, teacherId), eq(teacherClassGrants.classId, classId)))
-      .limit(1);
-
-    if (existing.length > 0) {
-      return;
-    }
-
+  async assignClassGrant(
+    teacherId: string,
+    classId: number,
+    accessLevel: "read" | "manage"
+  ): Promise<void> {
     await db.insert(teacherClassGrants).values({
       teacherId,
-      classId
+      classId,
+      accessLevel
+    }).onDuplicateKeyUpdate({
+      set: {
+        accessLevel
+      }
     });
   },
   async revokeClassGrant(teacherId: string, classId: number): Promise<void> {

--- a/src/modules/authorization/grant-service.ts
+++ b/src/modules/authorization/grant-service.ts
@@ -1,15 +1,17 @@
 export type GrantType = "student" | "class";
+export type AccessLevel = "read" | "manage";
 
 export interface AuthorizationGrantInput {
   grantType: GrantType;
   teacherId: string;
   targetId: number;
+  accessLevel?: AccessLevel;
 }
 
 export interface AuthorizationGrantRepository {
-  assignStudentGrant(teacherId: string, studentId: number): Promise<void>;
+  assignStudentGrant(teacherId: string, studentId: number, accessLevel: AccessLevel): Promise<void>;
   revokeStudentGrant(teacherId: string, studentId: number): Promise<void>;
-  assignClassGrant(teacherId: string, classId: number): Promise<void>;
+  assignClassGrant(teacherId: string, classId: number, accessLevel: AccessLevel): Promise<void>;
   revokeClassGrant(teacherId: string, classId: number): Promise<void>;
 }
 
@@ -26,13 +28,14 @@ export const createAuthorizationGrantService = ({
   authorizationGrantRepo
 }: CreateAuthorizationGrantServiceInput): AuthorizationGrantService => {
   return {
-    async assignGrant({ grantType, teacherId, targetId }: AuthorizationGrantInput): Promise<void> {
+    async assignGrant({ grantType, teacherId, targetId, accessLevel }: AuthorizationGrantInput): Promise<void> {
+      const resolvedAccessLevel: AccessLevel = accessLevel ?? "read";
       if (grantType === "student") {
-        await authorizationGrantRepo.assignStudentGrant(teacherId, targetId);
+        await authorizationGrantRepo.assignStudentGrant(teacherId, targetId, resolvedAccessLevel);
         return;
       }
 
-      await authorizationGrantRepo.assignClassGrant(teacherId, targetId);
+      await authorizationGrantRepo.assignClassGrant(teacherId, targetId, resolvedAccessLevel);
     },
 
     async revokeGrant({ grantType, teacherId, targetId }: AuthorizationGrantInput): Promise<void> {

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { ActivityService, ActivityType } from "../modules/activity/service.js";
 import type { AuditLogService } from "../modules/audit/service.js";
-import type { AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
+import type { AccessLevel, AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
 import {
   type DashboardDimension,
   type DashboardDimensionAggregationService,
@@ -32,6 +32,11 @@ interface AdminGrantRequestBody {
   grantType: GrantType;
   teacherId: string;
   targetId: number;
+  accessLevel?: AccessLevel;
+}
+
+interface AdminBatchGrantBody {
+  grants: AdminGrantRequestBody[];
 }
 
 interface AdminPublishActivityRequestBody {
@@ -126,6 +131,10 @@ const isValidGrantType = (grantType: unknown): grantType is GrantType => {
   return grantType === "student" || grantType === "class";
 };
 
+const isValidAccessLevel = (accessLevel: unknown): accessLevel is AccessLevel => {
+  return accessLevel === "read" || accessLevel === "manage";
+};
+
 const parsePositiveInteger = (rawId: string): number | null => {
   if (!/^[1-9]\d*$/.test(rawId)) {
     return null;
@@ -156,8 +165,26 @@ const isValidGrantBody = (body: unknown): body is AdminGrantRequestBody => {
   const grantType = (body as { grantType?: unknown }).grantType;
   const teacherId = (body as { teacherId?: unknown }).teacherId;
   const targetId = parseTargetId((body as { targetId?: unknown }).targetId);
+  const accessLevel = (body as { accessLevel?: unknown }).accessLevel;
+  const hasValidAccessLevel =
+    accessLevel === undefined || accessLevel === null || isValidAccessLevel(accessLevel);
 
-  return isValidGrantType(grantType) && typeof teacherId === "string" && teacherId.trim().length > 0 && !!targetId;
+  return (
+    isValidGrantType(grantType) &&
+    typeof teacherId === "string" &&
+    teacherId.trim().length > 0 &&
+    !!targetId &&
+    hasValidAccessLevel
+  );
+};
+
+const isValidBatchGrantBody = (body: unknown): body is AdminBatchGrantBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const grants = (body as { grants?: unknown }).grants;
+  return Array.isArray(grants) && grants.length > 0 && grants.every((grant) => isValidGrantBody(grant));
 };
 
 const isValidActivityType = (activityType: unknown): activityType is ActivityType => {
@@ -628,7 +655,8 @@ export const createAdminRoutes = ({
     await authorizationGrantService.assignGrant({
       grantType: body.grantType,
       teacherId: body.teacherId.trim(),
-      targetId: body.targetId
+      targetId: body.targetId,
+      accessLevel: body.accessLevel ?? "read"
     });
 
     await auditLogService.logAuthorizationGrant({
@@ -674,6 +702,81 @@ export const createAdminRoutes = ({
     });
 
     return c.json({ message: "authorization revoked" }, 200);
+  });
+
+  admin.post("/authorizations/grants/batch", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidBatchGrantBody(body)) {
+      return c.json({ message: "grants is required and must be valid array" }, 400);
+    }
+
+    for (const grant of body.grants) {
+      await authorizationGrantService.assignGrant({
+        grantType: grant.grantType,
+        teacherId: grant.teacherId.trim(),
+        targetId: grant.targetId,
+        accessLevel: grant.accessLevel ?? "read"
+      });
+
+      await auditLogService.logAuthorizationGrant({
+        operator,
+        teacherId: grant.teacherId.trim(),
+        grantType: grant.grantType,
+        targetId: grant.targetId
+      });
+    }
+
+    return c.json({ message: "authorization granted", count: body.grants.length }, 200);
+  });
+
+  admin.delete("/authorizations/grants/batch", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidBatchGrantBody(body)) {
+      return c.json({ message: "grants is required and must be valid array" }, 400);
+    }
+
+    for (const grant of body.grants) {
+      await authorizationGrantService.revokeGrant({
+        grantType: grant.grantType,
+        teacherId: grant.teacherId.trim(),
+        targetId: grant.targetId
+      });
+
+      await auditLogService.logAuthorizationRevoke({
+        operator,
+        teacherId: grant.teacherId.trim(),
+        grantType: grant.grantType,
+        targetId: grant.targetId
+      });
+    }
+
+    return c.json({ message: "authorization revoked", count: body.grants.length }, 200);
   });
 
   admin.post("/activities", async (c) => {

--- a/tests/auth/admin-audit-operations.test.ts
+++ b/tests/auth/admin-audit-operations.test.ts
@@ -6,7 +6,7 @@ import type { PublishActivityInput } from "../../src/modules/activity/service.ts
 import type { AuthorizationGrantInput } from "../../src/modules/authorization/grant-service.ts";
 
 interface OperationFixture {
-  assigned: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number }>;
+  assigned: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number; accessLevel?: "read" | "manage" }>;
   revoked: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number }>;
   published: Array<{ activityType: "course" | "competition" | "project"; title: string }>;
   auditActions: string[];
@@ -129,4 +129,58 @@ test("admin activity publish endpoint should write audit log", async () => {
   assert.equal(publishRes.status, 201);
   assert.equal(fixture.published.length, 1);
   assert.deepEqual(fixture.auditActions, ["activity_publish"]);
+});
+
+test("admin authorization batch grant/revoke should support multiple items and accessLevel", async () => {
+  const fixture: OperationFixture = {
+    assigned: [],
+    revoked: [],
+    published: [],
+    auditActions: []
+  };
+  const app = buildApp(fixture);
+
+  const grantRes = await app.request("/admin/authorizations/grants/batch", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-001"
+    },
+    body: JSON.stringify({
+      grants: [
+        { grantType: "class", teacherId: "teacher-1", targetId: 11, accessLevel: "manage" },
+        { grantType: "student", teacherId: "teacher-1", targetId: 1001, accessLevel: "read" }
+      ]
+    })
+  });
+
+  assert.equal(grantRes.status, 200);
+  assert.equal(fixture.assigned.length, 2);
+  assert.equal(fixture.assigned[0].accessLevel, "manage");
+  assert.equal(fixture.assigned[1].accessLevel, "read");
+
+  const revokeRes = await app.request("/admin/authorizations/grants/batch", {
+    method: "DELETE",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-001"
+    },
+    body: JSON.stringify({
+      grants: [
+        { grantType: "class", teacherId: "teacher-1", targetId: 11 },
+        { grantType: "student", teacherId: "teacher-1", targetId: 1001 }
+      ]
+    })
+  });
+
+  assert.equal(revokeRes.status, 200);
+  assert.equal(fixture.revoked.length, 2);
+  assert.deepEqual(fixture.auditActions, [
+    "authorization_grant",
+    "authorization_grant",
+    "authorization_revoke",
+    "authorization_revoke"
+  ]);
 });

--- a/tests/authorization/grant-service.test.ts
+++ b/tests/authorization/grant-service.test.ts
@@ -1,0 +1,32 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createAuthorizationGrantService } from "../../src/modules/authorization/grant-service.ts";
+
+test("authorization grant service should default accessLevel to read", async () => {
+  const calls: Array<{ grantType: "student" | "class"; accessLevel: "read" | "manage" }> = [];
+  const service = createAuthorizationGrantService({
+    authorizationGrantRepo: {
+      async assignStudentGrant(_teacherId, _studentId, accessLevel) {
+        calls.push({ grantType: "student", accessLevel });
+      },
+      async revokeStudentGrant() {},
+      async assignClassGrant(_teacherId, _classId, accessLevel) {
+        calls.push({ grantType: "class", accessLevel });
+      },
+      async revokeClassGrant() {}
+    }
+  });
+
+  await service.assignGrant({ grantType: "student", teacherId: "T-1", targetId: 1 });
+  await service.assignGrant({
+    grantType: "class",
+    teacherId: "T-1",
+    targetId: 2,
+    accessLevel: "manage"
+  });
+
+  assert.deepEqual(calls, [
+    { grantType: "student", accessLevel: "read" },
+    { grantType: "class", accessLevel: "manage" }
+  ]);
+});

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 13, "journal should contain at least 13 entries");
+  assert.ok(entries.length >= 14, "journal should contain at least 14 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011", "0012"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011", "0012", "0013", "0014"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -222,4 +222,16 @@ test("0013 migration file should include teachers table", () => {
   assert.match(migrationSql, /CREATE TABLE\s+`teachers`/i);
   assert.match(migrationSql, /`account`\s+varchar\(64\)\s+NOT\s+NULL/i);
   assert.match(migrationSql, /UNIQUE\(`teacher_id`\)/i);
+});
+
+test("0014 migration file should include access_level for teacher grants", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0014 = migrationFiles.find((fileName) => /^0014_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0014, "expected a 0014 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0014), "utf8");
+  assert.match(migrationSql, /ALTER TABLE\s+`teacher_student_grants`/i);
+  assert.match(migrationSql, /ALTER TABLE\s+`teacher_class_grants`/i);
+  assert.match(migrationSql, /`access_level`\s+enum\('read','manage'\)/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -66,7 +66,9 @@ test("schema should include resource and grant authorization tables", () => {
   assert.equal(certificates.studentId.name, "student_id");
   assert.equal(profiles.studentId.name, "student_id");
   assert.equal(teacherStudentGrants.teacherId.name, "teacher_id");
+  assert.equal(teacherStudentGrants.accessLevel.name, "access_level");
   assert.equal(teacherClassGrants.classId.name, "class_id");
+  assert.equal(teacherClassGrants.accessLevel.name, "access_level");
 });
 
 test("schema should include activity and audit log tables", () => {

--- a/tests/teacher/my-students.test.ts
+++ b/tests/teacher/my-students.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { Hono } from "hono";
 import { createTeacherMyStudentsService, type TeacherMyStudentsRepository } from "../../src/modules/teacher/my-students.ts";
+import { createAuthorizationGrantService } from "../../src/modules/authorization/grant-service.ts";
 import { createTeacherRoutes } from "../../src/routes/teacher.ts";
 
 test("teacher my students service should keep stable pagination order by studentId", async () => {
@@ -136,4 +137,83 @@ test("GET /teacher/my-students should support filters and pagination", async () 
   const payload = await response.json();
   assert.equal(payload.total, 1);
   assert.equal(payload.items[0].studentNo, "S20260012");
+});
+
+test("teacher visible students should be affected immediately after grant and revoke", async () => {
+  const teacherId = "T-1";
+  const classGrants = new Set<number>();
+  const studentsByClass = new Map<number, number[]>([
+    [10, [1001, 1002]]
+  ]);
+
+  const grantService = createAuthorizationGrantService({
+    authorizationGrantRepo: {
+      async assignStudentGrant() {},
+      async revokeStudentGrant() {},
+      async assignClassGrant(_teacherId, classId) {
+        classGrants.add(classId);
+      },
+      async revokeClassGrant(_teacherId, classId) {
+        classGrants.delete(classId);
+      }
+    }
+  });
+
+  const service = createTeacherMyStudentsService({
+    teacherMyStudentsRepo: {
+      async listAuthorizedStudents(query) {
+        assert.equal(query.teacherId, teacherId);
+        const rows = Array.from(classGrants).flatMap((classId) =>
+          (studentsByClass.get(classId) ?? []).map((studentId) => ({
+            studentId,
+            studentNo: `S${studentId}`,
+            name: `学生${studentId}`,
+            classId,
+            className: `${classId}班`,
+            majorId: null,
+            majorName: null,
+            grade: 2024,
+            assessmentDone: false,
+            reportGenerated: false
+          }))
+        );
+        return { total: rows.length, rows };
+      }
+    }
+  });
+
+  const beforeGrant = await service.getMyStudents({
+    teacherId,
+    page: 1,
+    pageSize: 20,
+    filters: {}
+  });
+  assert.equal(beforeGrant.total, 0);
+
+  await grantService.assignGrant({
+    grantType: "class",
+    teacherId,
+    targetId: 10,
+    accessLevel: "manage"
+  });
+  const afterGrant = await service.getMyStudents({
+    teacherId,
+    page: 1,
+    pageSize: 20,
+    filters: {}
+  });
+  assert.equal(afterGrant.total, 2);
+
+  await grantService.revokeGrant({
+    grantType: "class",
+    teacherId,
+    targetId: 10
+  });
+  const afterRevoke = await service.getMyStudents({
+    teacherId,
+    page: 1,
+    pageSize: 20,
+    filters: {}
+  });
+  assert.equal(afterRevoke.total, 0);
 });


### PR DESCRIPTION
Closes #26

## 变更内容
- 授权中心新增批量授权与批量撤销接口：`POST /admin/authorizations/grants/batch`、`DELETE /admin/authorizations/grants/batch`
- 单条与批量授权均支持 `accessLevel`（`read`/`manage`），默认 `read`
- 授权存储表新增 `access_level` 字段，并支持重复授权时级别更新
- 增加授权变更即时影响教师可见范围的服务级测试

## 数据库变更
- 新增迁移 `0014_grant_access_level.sql`
  - `teacher_student_grants.access_level`
  - `teacher_class_grants.access_level`

## 测试
- `npm test` 全量通过（136/136）
- 新增/更新测试覆盖：授权批量接口、accessLevel 默认行为、迁移与schema校验、授权即时生效