### PR TITLE
feat: 实现活动中心发布范围与状态追踪接口

### DIFF
--- a/drizzle/0015_activity_center_fields.sql
+++ b/drizzle/0015_activity_center_fields.sql
@@ -1,0 +1,14 @@
+ALTER TABLE `activities`
+  ADD `scope_type` enum('school','college','class') NOT NULL DEFAULT 'school',
+  ADD `scope_target_id` int NOT NULL DEFAULT 0,
+  ADD `owner_teacher_id` varchar(64) NOT NULL DEFAULT 'T-UNKNOWN',
+  ADD `start_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD `end_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  ADD `timeline_json` text,
+  ADD `status` enum('draft','published','closed') NOT NULL DEFAULT 'published';
+
+UPDATE `activities` SET `timeline_json` = '[]' WHERE `timeline_json` IS NULL;
+ALTER TABLE `activities` MODIFY `timeline_json` text NOT NULL;
+
+CREATE INDEX `activities_status_idx` ON `activities` (`status`);
+CREATE INDEX `activities_owner_teacher_id_idx` ON `activities` (`owner_teacher_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1772419007433,
       "tag": "0014_grant_access_level",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "5",
+      "when": 1772419208778,
+      "tag": "0015_activity_center_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -291,10 +291,19 @@ export const activities = mysqlTable(
     id: int("id").autoincrement().primaryKey(),
     activityType: mysqlEnum("activity_type", ["course", "competition", "project"]).notNull(),
     title: varchar("title", { length: 128 }).notNull(),
+    scopeType: mysqlEnum("scope_type", ["school", "college", "class"]).notNull().default("school"),
+    scopeTargetId: int("scope_target_id").notNull().default(0),
+    ownerTeacherId: varchar("owner_teacher_id", { length: 64 }).notNull(),
+    startAt: timestamp("start_at").notNull().defaultNow(),
+    endAt: timestamp("end_at").notNull().defaultNow(),
+    timelineJson: text("timeline_json").notNull(),
+    status: mysqlEnum("status", ["draft", "published", "closed"]).notNull().default("published"),
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   (table) => ({
-    activityTypeIdx: index("activities_activity_type_idx").on(table.activityType)
+    activityTypeIdx: index("activities_activity_type_idx").on(table.activityType),
+    statusIdx: index("activities_status_idx").on(table.status),
+    ownerTeacherIdIdx: index("activities_owner_teacher_id_idx").on(table.ownerTeacherId)
   })
 );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -783,15 +783,74 @@ const authorizationGrantService = createAuthorizationGrantService({
 const activityRepo = {
   async publishActivity({
     activityType,
-    title
+    title,
+    scopeType,
+    scopeTargetId,
+    ownerTeacherId,
+    startAt,
+    endAt,
+    timelineNodes,
+    status
   }: {
     activityType: "course" | "competition" | "project";
     title: string;
-  }): Promise<void> {
-    await db.insert(activities).values({
+    scopeType: "school" | "college" | "class";
+    scopeTargetId: number;
+    ownerTeacherId: string;
+    startAt: Date;
+    endAt: Date;
+    timelineNodes: Array<{ key: string; at: string }>;
+    status: "draft" | "published" | "closed";
+  }): Promise<{ activityId: number }> {
+    const inserted = await db.insert(activities).values({
       activityType,
-      title
+      title,
+      scopeType,
+      scopeTargetId,
+      ownerTeacherId,
+      startAt,
+      endAt,
+      timelineJson: JSON.stringify(timelineNodes),
+      status
     });
+
+    const activityId = Number(inserted[0].insertId);
+    await db.insert(teacherActivityAssignments).values({
+      activityId,
+      teacherId: ownerTeacherId
+    }).onDuplicateKeyUpdate({
+      set: { teacherId: ownerTeacherId }
+    });
+    return { activityId };
+  },
+  async listActivities() {
+    const rows = await db
+      .select({
+        activityId: activities.id,
+        activityType: activities.activityType,
+        title: activities.title,
+        scopeType: activities.scopeType,
+        scopeTargetId: activities.scopeTargetId,
+        ownerTeacherId: activities.ownerTeacherId,
+        startAt: activities.startAt,
+        endAt: activities.endAt,
+        status: activities.status,
+        timelineJson: activities.timelineJson
+      })
+      .from(activities);
+
+    return rows.map((row) => ({
+      activityId: row.activityId,
+      activityType: row.activityType,
+      title: row.title,
+      scopeType: row.scopeType,
+      scopeTargetId: row.scopeTargetId,
+      ownerTeacherId: row.ownerTeacherId,
+      startAt: row.startAt,
+      endAt: row.endAt,
+      status: row.status,
+      timelineNodes: JSON.parse(row.timelineJson) as Array<{ key: string; at: string }>
+    }));
   }
 };
 

--- a/src/modules/activity/service.ts
+++ b/src/modules/activity/service.ts
@@ -1,16 +1,45 @@
 export type ActivityType = "course" | "competition" | "project";
+export type ActivityScopeType = "school" | "college" | "class";
+export type ActivityStatus = "draft" | "published" | "closed";
+
+export interface ActivityTimelineNode {
+  key: string;
+  at: string;
+}
 
 export interface PublishActivityInput {
   activityType: ActivityType;
   title: string;
+  scopeType: ActivityScopeType;
+  scopeTargetId: number;
+  ownerTeacherId: string;
+  startAt: Date;
+  endAt: Date;
+  timelineNodes: ActivityTimelineNode[];
+  status?: ActivityStatus;
+}
+
+export interface ActivitySummary {
+  activityId: number;
+  activityType: ActivityType;
+  title: string;
+  scopeType: ActivityScopeType;
+  scopeTargetId: number;
+  ownerTeacherId: string;
+  startAt: Date;
+  endAt: Date;
+  status: ActivityStatus;
+  timelineNodes: ActivityTimelineNode[];
 }
 
 export interface ActivityRepository {
-  publishActivity(input: PublishActivityInput): Promise<void>;
+  publishActivity(input: PublishActivityInput): Promise<{ activityId: number }>;
+  listActivities(): Promise<ActivitySummary[]>;
 }
 
 export interface ActivityService {
-  publishActivity(input: PublishActivityInput): Promise<void>;
+  publishActivity(input: PublishActivityInput): Promise<{ activityId: number }>;
+  listActivities(): Promise<ActivitySummary[]>;
 }
 
 export interface CreateActivityServiceInput {
@@ -19,8 +48,18 @@ export interface CreateActivityServiceInput {
 
 export const createActivityService = ({ activityRepo }: CreateActivityServiceInput): ActivityService => {
   return {
-    async publishActivity(input: PublishActivityInput): Promise<void> {
-      await activityRepo.publishActivity(input);
+    async publishActivity(input: PublishActivityInput): Promise<{ activityId: number }> {
+      if (input.endAt.getTime() < input.startAt.getTime()) {
+        throw new Error("activity endAt must be greater than or equal to startAt");
+      }
+
+      return activityRepo.publishActivity({
+        ...input,
+        status: input.status ?? "published"
+      });
+    },
+    async listActivities(): Promise<ActivitySummary[]> {
+      return activityRepo.listActivities();
     }
   };
 };

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
-import type { ActivityService, ActivityType } from "../modules/activity/service.js";
+import type {
+  ActivityScopeType,
+  ActivityService,
+  ActivityTimelineNode,
+  ActivityType
+} from "../modules/activity/service.js";
 import type { AuditLogService } from "../modules/audit/service.js";
 import type { AccessLevel, AuthorizationGrantService, GrantType } from "../modules/authorization/grant-service.js";
 import {
@@ -42,6 +47,12 @@ interface AdminBatchGrantBody {
 interface AdminPublishActivityRequestBody {
   activityType: ActivityType;
   title: string;
+  scopeType: ActivityScopeType;
+  scopeTargetId: number;
+  ownerTeacherId: string;
+  startAt: string;
+  endAt: string;
+  timelineNodes: ActivityTimelineNode[];
 }
 
 interface AdminCollegeCreateBody {
@@ -73,7 +84,8 @@ interface AdminStudentArchiveCreateBody {
 export interface AdminRouteDependencies {
   studentAuthService: Pick<StudentAuthService, "resetStudentPasswordByAdmin">;
   authorizationGrantService: Pick<AuthorizationGrantService, "assignGrant" | "revokeGrant">;
-  activityService: Pick<ActivityService, "publishActivity">;
+  activityService: Pick<ActivityService, "publishActivity"> &
+    Partial<Pick<ActivityService, "listActivities">>;
   auditLogService: Pick<
     AuditLogService,
     "logAuthorizationGrant" | "logAuthorizationRevoke" | "logPasswordReset" | "logActivityPublish"
@@ -191,6 +203,31 @@ const isValidActivityType = (activityType: unknown): activityType is ActivityTyp
   return activityType === "course" || activityType === "competition" || activityType === "project";
 };
 
+const isValidActivityScopeType = (scopeType: unknown): scopeType is ActivityScopeType => {
+  return scopeType === "school" || scopeType === "college" || scopeType === "class";
+};
+
+const isValidDateTime = (value: unknown): value is string => {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+  return !Number.isNaN(new Date(value).getTime());
+};
+
+const isValidTimelineNodes = (value: unknown): value is ActivityTimelineNode[] => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every((node) => {
+    if (!node || typeof node !== "object") {
+      return false;
+    }
+    const key = (node as { key?: unknown }).key;
+    const at = (node as { at?: unknown }).at;
+    return typeof key === "string" && key.trim().length > 0 && isValidDateTime(at);
+  });
+};
+
 const isValidPublishActivityBody = (body: unknown): body is AdminPublishActivityRequestBody => {
   if (!body || typeof body !== "object") {
     return false;
@@ -198,8 +235,25 @@ const isValidPublishActivityBody = (body: unknown): body is AdminPublishActivity
 
   const activityType = (body as { activityType?: unknown }).activityType;
   const title = (body as { title?: unknown }).title;
+  const scopeType = (body as { scopeType?: unknown }).scopeType;
+  const scopeTargetId = parseTargetId((body as { scopeTargetId?: unknown }).scopeTargetId);
+  const ownerTeacherId = (body as { ownerTeacherId?: unknown }).ownerTeacherId;
+  const startAt = (body as { startAt?: unknown }).startAt;
+  const endAt = (body as { endAt?: unknown }).endAt;
+  const timelineNodes = (body as { timelineNodes?: unknown }).timelineNodes;
 
-  return isValidActivityType(activityType) && typeof title === "string" && title.trim().length > 0;
+  return (
+    isValidActivityType(activityType) &&
+    typeof title === "string" &&
+    title.trim().length > 0 &&
+    isValidActivityScopeType(scopeType) &&
+    !!scopeTargetId &&
+    typeof ownerTeacherId === "string" &&
+    ownerTeacherId.trim().length > 0 &&
+    isValidDateTime(startAt) &&
+    isValidDateTime(endAt) &&
+    isValidTimelineNodes(timelineNodes)
+  );
 };
 
 const isForbiddenByAdminKey = (requestAdminKey: string | undefined, adminApiKey: string): boolean => {
@@ -795,12 +849,18 @@ export const createAdminRoutes = ({
     }
 
     if (!isValidPublishActivityBody(body)) {
-      return c.json({ message: "activityType/title is required" }, 400);
+      return c.json({ message: "activity publish payload is invalid" }, 400);
     }
 
     await activityService.publishActivity({
       activityType: body.activityType,
-      title: body.title.trim()
+      title: body.title.trim(),
+      scopeType: body.scopeType,
+      scopeTargetId: body.scopeTargetId,
+      ownerTeacherId: body.ownerTeacherId.trim(),
+      startAt: new Date(body.startAt),
+      endAt: new Date(body.endAt),
+      timelineNodes: body.timelineNodes
     });
 
     await auditLogService.logActivityPublish({
@@ -810,6 +870,26 @@ export const createAdminRoutes = ({
     });
 
     return c.json({ message: "activity published" }, 201);
+  });
+
+  admin.get("/activities", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    if (!activityService.listActivities) {
+      return c.json({ message: "activity list service not configured" }, 500);
+    }
+
+    const activities = await activityService.listActivities();
+    return c.json({
+      items: activities.map((activity) => ({
+        ...activity,
+        startAt: activity.startAt.toISOString(),
+        endAt: activity.endAt.toISOString()
+      }))
+    }, 200);
   });
 
   admin.post("/imports/excel/validate", async (c) => {

--- a/tests/activity/service.test.ts
+++ b/tests/activity/service.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createActivityService } from "../../src/modules/activity/service.ts";
+
+test("activity service should reject endAt earlier than startAt", async () => {
+  const service = createActivityService({
+    activityRepo: {
+      async publishActivity() {
+        return { activityId: 1 };
+      },
+      async listActivities() {
+        return [];
+      }
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      service.publishActivity({
+        activityType: "course",
+        title: "就业指导课",
+        scopeType: "class",
+        scopeTargetId: 11,
+        ownerTeacherId: "teacher-1",
+        startAt: new Date("2026-03-10T08:00:00.000Z"),
+        endAt: new Date("2026-03-02T08:00:00.000Z"),
+        timelineNodes: []
+      }),
+    /endAt/
+  );
+});

--- a/tests/admin/org-teacher-account.test.ts
+++ b/tests/admin/org-teacher-account.test.ts
@@ -19,7 +19,7 @@ const baseDependencies = {
   },
   activityService: {
     async publishActivity() {
-      return;
+      return { activityId: 1 };
     }
   },
   auditLogService: {

--- a/tests/admin/student-archive.test.ts
+++ b/tests/admin/student-archive.test.ts
@@ -19,7 +19,7 @@ const baseDependencies = {
   },
   activityService: {
     async publishActivity() {
-      return;
+      return { activityId: 1 };
     }
   },
   auditLogService: {

--- a/tests/auth/admin-audit-operations.test.ts
+++ b/tests/auth/admin-audit-operations.test.ts
@@ -8,7 +8,17 @@ import type { AuthorizationGrantInput } from "../../src/modules/authorization/gr
 interface OperationFixture {
   assigned: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number; accessLevel?: "read" | "manage" }>;
   revoked: Array<{ grantType: "student" | "class"; teacherId: string; targetId: number }>;
-  published: Array<{ activityType: "course" | "competition" | "project"; title: string }>;
+  published: Array<{
+    activityType: "course" | "competition" | "project";
+    title: string;
+    scopeType: "school" | "college" | "class";
+    scopeTargetId: number;
+    ownerTeacherId: string;
+    startAt: Date;
+    endAt: Date;
+    timelineNodes: Array<{ key: string; at: string }>;
+    status?: "draft" | "published" | "closed";
+  }>;
   auditActions: string[];
 }
 
@@ -37,6 +47,10 @@ const buildApp = (fixture: OperationFixture) => {
       activityService: {
         async publishActivity(input: PublishActivityInput) {
           fixture.published.push(input);
+          return { activityId: 1 };
+        },
+        async listActivities() {
+          return [];
         }
       },
       auditLogService: {
@@ -122,7 +136,16 @@ test("admin activity publish endpoint should write audit log", async () => {
     },
     body: JSON.stringify({
       activityType: "course",
-      title: "就业指导课"
+      title: "就业指导课",
+      scopeType: "class",
+      scopeTargetId: 11,
+      ownerTeacherId: "teacher-1",
+      startAt: "2026-03-02T08:00:00.000Z",
+      endAt: "2026-03-10T08:00:00.000Z",
+      timelineNodes: [
+        { key: "signup", at: "2026-03-03T08:00:00.000Z" },
+        { key: "execute", at: "2026-03-08T08:00:00.000Z" }
+      ]
     })
   });
 
@@ -183,4 +206,85 @@ test("admin authorization batch grant/revoke should support multiple items and a
     "authorization_revoke",
     "authorization_revoke"
   ]);
+});
+
+test("admin activity publish should return 400 when payload missing scope/owner/time", async () => {
+  const fixture: OperationFixture = {
+    assigned: [],
+    revoked: [],
+    published: [],
+    auditActions: []
+  };
+  const app = buildApp(fixture);
+
+  const publishRes = await app.request("/admin/activities", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "X-Admin-Key": adminApiKey,
+      "X-Admin-Operator-Id": "admin-002"
+    },
+    body: JSON.stringify({
+      activityType: "course",
+      title: "就业指导课"
+    })
+  });
+
+  assert.equal(publishRes.status, 400);
+});
+
+test("admin should list activity statuses", async () => {
+  const app = new Hono();
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      adminApiKey,
+      authorizationGrantService: {
+        async assignGrant() {},
+        async revokeGrant() {}
+      },
+      activityService: {
+        async publishActivity() {
+          return { activityId: 1 };
+        },
+        async listActivities() {
+          return [
+            {
+              activityId: 1,
+              activityType: "course" as const,
+              title: "就业指导课",
+              scopeType: "class" as const,
+              scopeTargetId: 11,
+              ownerTeacherId: "teacher-1",
+              startAt: new Date("2026-03-02T08:00:00.000Z"),
+              endAt: new Date("2026-03-10T08:00:00.000Z"),
+              status: "published" as const,
+              timelineNodes: [{ key: "execute", at: "2026-03-08T08:00:00.000Z" }]
+            }
+          ];
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {},
+        async logAuthorizationRevoke() {},
+        async logPasswordReset() {},
+        async logActivityPublish() {}
+      }
+    })
+  );
+
+  const response = await app.request("/admin/activities", {
+    method: "GET",
+    headers: { "X-Admin-Key": adminApiKey }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.items.length, 1);
+  assert.equal(payload.items[0].status, "published");
 });

--- a/tests/auth/admin-reset-password.test.ts
+++ b/tests/auth/admin-reset-password.test.ts
@@ -71,7 +71,7 @@ function buildApp(ctx: TestContext): Hono {
       },
       activityService: {
         async publishActivity() {
-          return;
+          return { activityId: 1 };
         }
       },
       auditLogService: {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -18,13 +18,13 @@ test("drizzle migration metadata chain should be continuous", () => {
   const entries = journal.entries as Array<{ idx: number; tag: string }>;
 
   assert.ok(Array.isArray(entries), "journal entries should be an array");
-  assert.ok(entries.length >= 14, "journal should contain at least 14 entries");
+  assert.ok(entries.length >= 15, "journal should contain at least 15 entries");
 
   entries.forEach((entry, index) => {
     assert.equal(entry.idx, index, `journal idx should be continuous at ${index}`);
   });
 
-  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011", "0012", "0013", "0014"]) {
+  for (const prefix of ["0000", "0001", "0002", "0003", "0004", "0005", "0006", "0007", "0008", "0009", "0010", "0011", "0012", "0013", "0014", "0015"]) {
     assert.ok(
       entries.some((entry) => entry.tag.startsWith(`${prefix}_`)),
       `journal should include migration ${prefix}`
@@ -234,4 +234,18 @@ test("0014 migration file should include access_level for teacher grants", () =>
   assert.match(migrationSql, /ALTER TABLE\s+`teacher_student_grants`/i);
   assert.match(migrationSql, /ALTER TABLE\s+`teacher_class_grants`/i);
   assert.match(migrationSql, /`access_level`\s+enum\('read','manage'\)/i);
+});
+
+test("0015 migration file should include activity center fields", () => {
+  const migrationFiles = fs.readdirSync(drizzleDir);
+  const migration0015 = migrationFiles.find((fileName) => /^0015_.*\.sql$/.test(fileName));
+
+  assert.ok(migration0015, "expected a 0015 migration SQL file");
+
+  const migrationSql = fs.readFileSync(path.join(drizzleDir, migration0015), "utf8");
+  assert.match(migrationSql, /ALTER TABLE\s+`activities`/i);
+  assert.match(migrationSql, /`scope_type`\s+enum\('school','college','class'\)/i);
+  assert.match(migrationSql, /`owner_teacher_id`\s+varchar\(64\)/i);
+  assert.match(migrationSql, /`timeline_json`\s+text/i);
+  assert.match(migrationSql, /`status`\s+enum\('draft','published','closed'\)/i);
 });

--- a/tests/db/schema.test.ts
+++ b/tests/db/schema.test.ts
@@ -77,6 +77,13 @@ test("schema should include activity and audit log tables", () => {
 
   assert.equal(activities.activityType.name, "activity_type");
   assert.equal(activities.title.name, "title");
+  assert.equal(activities.scopeType.name, "scope_type");
+  assert.equal(activities.scopeTargetId.name, "scope_target_id");
+  assert.equal(activities.ownerTeacherId.name, "owner_teacher_id");
+  assert.equal(activities.startAt.name, "start_at");
+  assert.equal(activities.endAt.name, "end_at");
+  assert.equal(activities.timelineJson.name, "timeline_json");
+  assert.equal(activities.status.name, "status");
 
   assert.equal(auditLogs.operator.name, "operator");
   assert.equal(auditLogs.action.name, "action");

--- a/tests/import/admin-excel-import.test.ts
+++ b/tests/import/admin-excel-import.test.ts
@@ -39,7 +39,7 @@ const createNoopAdminApp = (
       },
       activityService: {
         async publishActivity() {
-          return;
+          return { activityId: 1 };
         }
       },
       auditLogService: {

--- a/tests/metrics/admin-dimension-aggregation.test.ts
+++ b/tests/metrics/admin-dimension-aggregation.test.ts
@@ -34,7 +34,7 @@ const createApp = (calls: CallSnapshot[] = []) => {
       },
       activityService: {
         async publishActivity() {
-          return;
+          return { activityId: 1 };
         }
       },
       auditLogService: {

--- a/tests/metrics/admin-trend-funnel.test.ts
+++ b/tests/metrics/admin-trend-funnel.test.ts
@@ -26,7 +26,7 @@ const createApp = () => {
       },
       activityService: {
         async publishActivity() {
-          return;
+          return { activityId: 1 };
         }
       },
       auditLogService: {


### PR DESCRIPTION
Closes #27

## 变更内容
- 活动发布接口扩展：支持适用范围、负责人、起止时间、时间节点
- 活动模型新增状态字段（draft/published/closed）
- 新增管理员活动列表接口：`GET /admin/activities`，支持追踪活动状态
- 发布活动时自动写入负责人到执行分配表，教师可据此执行
- 保持活动发布审计日志能力

## 数据库变更
- 新增迁移 `0015_activity_center_fields.sql`
  - `activities` 增加 `scope_type/scope_target_id/owner_teacher_id/start_at/end_at/timeline_json/status`
  - 新增状态与负责人索引

## 测试
- `npm test` 全量通过（140/140）
- 新增/更新测试覆盖发布参数校验、状态查询接口、迁移与 schema 校验、活动时间合法性
