### PR TITLE
feat: 实现管理员驾驶舱全校视角接口

### DIFF
--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -277,6 +277,29 @@ const parsePositiveIntegerQuery = (raw: string | undefined): number | undefined 
   return Number.isSafeInteger(parsed) ? parsed : null;
 };
 
+const resolveDashboardFiltersFromQuery = (
+  query: (key: string) => string | undefined
+): { filters: DashboardFilters | null; hasInvalid: boolean } => {
+  const schoolId = parsePositiveIntegerQuery(query("schoolId"));
+  const collegeId = parsePositiveIntegerQuery(query("collegeId"));
+  const majorId = parsePositiveIntegerQuery(query("majorId"));
+  const classId = parsePositiveIntegerQuery(query("classId"));
+
+  if ([schoolId, collegeId, majorId, classId].some((value) => value === null)) {
+    return { filters: null, hasInvalid: true };
+  }
+
+  return {
+    hasInvalid: false,
+    filters: {
+      schoolId: schoolId as number | undefined,
+      collegeId: collegeId as number | undefined,
+      majorId: majorId as number | undefined,
+      classId: classId as number | undefined
+    }
+  };
+};
+
 const DASHBOARD_DATE_QUERY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 const isValidDateOnly = (rawDate: string): boolean => {
@@ -943,21 +966,10 @@ export const createAdminRoutes = ({
       return c.json({ message: "dimension must be college/major/class" }, 400);
     }
 
-    const schoolId = parsePositiveIntegerQuery(c.req.query("schoolId"));
-    const collegeId = parsePositiveIntegerQuery(c.req.query("collegeId"));
-    const majorId = parsePositiveIntegerQuery(c.req.query("majorId"));
-    const classId = parsePositiveIntegerQuery(c.req.query("classId"));
-
-    if ([schoolId, collegeId, majorId, classId].some((value) => value === null)) {
+    const { filters, hasInvalid } = resolveDashboardFiltersFromQuery((key) => c.req.query(key));
+    if (hasInvalid || !filters) {
       return c.json({ message: "organization filter must be positive integer" }, 400);
     }
-
-    const filters: DashboardFilters = {
-      schoolId: schoolId as number | undefined,
-      collegeId: collegeId as number | undefined,
-      majorId: majorId as number | undefined,
-      classId: classId as number | undefined
-    };
 
     const result = await dashboardDimensionAggregationService.aggregateByDimension({
       dimension: dimensionQuery,
@@ -973,12 +985,8 @@ export const createAdminRoutes = ({
       return c.json({ message: "forbidden" }, 403);
     }
 
-    const schoolId = parsePositiveIntegerQuery(c.req.query("schoolId"));
-    const collegeId = parsePositiveIntegerQuery(c.req.query("collegeId"));
-    const majorId = parsePositiveIntegerQuery(c.req.query("majorId"));
-    const classId = parsePositiveIntegerQuery(c.req.query("classId"));
-
-    if ([schoolId, collegeId, majorId, classId].some((value) => value === null)) {
+    const { filters, hasInvalid } = resolveDashboardFiltersFromQuery((key) => c.req.query(key));
+    if (hasInvalid || !filters) {
       return c.json({ message: "organization filter must be positive integer" }, 400);
     }
 
@@ -993,13 +1001,6 @@ export const createAdminRoutes = ({
       return c.json({ message: "startDate must be less than or equal to endDate" }, 400);
     }
 
-    const filters: DashboardFilters = {
-      schoolId: schoolId as number | undefined,
-      collegeId: collegeId as number | undefined,
-      majorId: majorId as number | undefined,
-      classId: classId as number | undefined
-    };
-
     try {
       const result = await dashboardTrendFunnelService.getTrendAndFunnel({
         filters,
@@ -1013,6 +1014,68 @@ export const createAdminRoutes = ({
         return c.json({ message: error.message }, 400);
       }
 
+      throw error;
+    }
+  });
+
+  admin.get("/dashboard/cockpit", async (c) => {
+    const requestAdminKey = c.req.header("x-admin-key");
+    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const dimensionQuery = c.req.query("dimension");
+    const dimension: DashboardDimension = isDashboardDimension(dimensionQuery)
+      ? dimensionQuery
+      : "college";
+
+    const { filters, hasInvalid } = resolveDashboardFiltersFromQuery((key) => c.req.query(key));
+    if (hasInvalid || !filters) {
+      return c.json({ message: "organization filter must be positive integer" }, 400);
+    }
+
+    const startDate = c.req.query("startDate");
+    const endDate = c.req.query("endDate");
+
+    if ((startDate && !isValidDateOnly(startDate)) || (endDate && !isValidDateOnly(endDate))) {
+      return c.json({ message: "startDate/endDate must be YYYY-MM-DD" }, 400);
+    }
+
+    if (startDate && endDate && startDate > endDate) {
+      return c.json({ message: "startDate must be less than or equal to endDate" }, 400);
+    }
+
+    try {
+      const [aggregation, trendFunnel] = await Promise.all([
+        dashboardDimensionAggregationService.aggregateByDimension({
+          dimension,
+          filters
+        }),
+        dashboardTrendFunnelService.getTrendAndFunnel({
+          filters,
+          startDate,
+          endDate
+        })
+      ]);
+
+      return c.json(
+        {
+          dictionaryVersion: aggregation.dictionaryVersion,
+          filters,
+          overview: aggregation.metricCards,
+          byDimension: {
+            dimension: aggregation.dimension,
+            barChart: aggregation.barChart,
+            stackedBarChart: aggregation.stackedBarChart
+          },
+          trendFunnel
+        },
+        200
+      );
+    } catch (error) {
+      if (error instanceof InvalidDashboardDateRangeError) {
+        return c.json({ message: error.message }, 400);
+      }
       throw error;
     }
   });

--- a/tests/metrics/admin-cockpit.test.ts
+++ b/tests/metrics/admin-cockpit.test.ts
@@ -1,0 +1,135 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono } from "hono";
+import { createAdminRoutes } from "../../src/routes/admin.ts";
+
+const adminApiKey = "admin-secret-key";
+
+const createApp = () => {
+  const app = new Hono();
+
+  app.route(
+    "/admin",
+    createAdminRoutes({
+      studentAuthService: {
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      authorizationGrantService: {
+        async assignGrant() {
+          return;
+        },
+        async revokeGrant() {
+          return;
+        }
+      },
+      activityService: {
+        async publishActivity() {
+          return { activityId: 1 };
+        },
+        async listActivities() {
+          return [];
+        }
+      },
+      auditLogService: {
+        async logAuthorizationGrant() {
+          return;
+        },
+        async logAuthorizationRevoke() {
+          return;
+        },
+        async logPasswordReset() {
+          return;
+        },
+        async logActivityPublish() {
+          return;
+        }
+      },
+      excelImportValidationService: {
+        async validateExcelImport() {
+          return { total: 0, success: 0, failed: 0, errors: [] };
+        }
+      },
+      dashboardDimensionAggregationService: {
+        async aggregateByDimension(input) {
+          return {
+            dictionaryVersion: "b07.v1",
+            dimension: input.dimension,
+            metricCards: {
+              activatedStudentsCount: 100,
+              assessmentCompletionRate: 0.8,
+              reportGenerationRate: 0.7,
+              taskCompletionRate: 0.6,
+              activityParticipationRate: 0.5
+            },
+            barChart: {
+              dimension: input.dimension,
+              categories: ["计算机学院"],
+              series: []
+            },
+            stackedBarChart: {
+              dimension: input.dimension,
+              categories: ["计算机学院"],
+              series: []
+            }
+          };
+        }
+      },
+      dashboardTrendFunnelService: {
+        async getTrendAndFunnel() {
+          return {
+            dictionaryVersion: "b07.v1",
+            dateRange: {
+              startDate: "2026-02-01",
+              endDate: "2026-03-02"
+            },
+            trend: [],
+            funnel: []
+          };
+        }
+      },
+      adminApiKey
+    })
+  );
+
+  return app;
+};
+
+test("admin cockpit should return full-school overview metrics and dimension views", async () => {
+  const app = createApp();
+
+  const response = await app.request(
+    "/admin/dashboard/cockpit?dimension=major&collegeId=1&startDate=2026-02-01&endDate=2026-03-02",
+    {
+      headers: {
+        "X-Admin-Key": adminApiKey
+      }
+    }
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as {
+    overview: { activatedStudentsCount: number; assessmentCompletionRate: number; reportGenerationRate: number; taskCompletionRate: number; activityParticipationRate: number };
+    byDimension: { dimension: string };
+  };
+
+  assert.equal(body.overview.activatedStudentsCount, 100);
+  assert.equal(body.overview.assessmentCompletionRate, 0.8);
+  assert.equal(body.overview.reportGenerationRate, 0.7);
+  assert.equal(body.overview.taskCompletionRate, 0.6);
+  assert.equal(body.overview.activityParticipationRate, 0.5);
+  assert.equal(body.byDimension.dimension, "major");
+});
+
+test("admin cockpit should return 400 for invalid filter", async () => {
+  const app = createApp();
+
+  const response = await app.request("/admin/dashboard/cockpit?collegeId=abc", {
+    headers: {
+      "X-Admin-Key": adminApiKey
+    }
+  });
+
+  assert.equal(response.status, 400);
+});


### PR DESCRIPTION
Closes #28

## 变更内容
- 新增管理员驾驶舱接口：`GET /admin/dashboard/cockpit`
- 返回统一驾驶舱结构：
  - `overview`：激活数、测评完成率、报告生成率、任务完成率、活动参与率
  - `byDimension`：按院系/专业/班级维度的图表数据
  - `trendFunnel`：趋势与漏斗
- 支持组织过滤：`schoolId/collegeId/majorId/classId`
- 支持维度参数：`dimension=college|major|class`（默认 college）

## 测试
- 新增 `tests/metrics/admin-cockpit.test.ts`
- `npm test` 全量通过（142/142）
