### PR TITLE
fix: 取消 JWT_SECRET 与 ADMIN_API_KEY 长度校验

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,7 +19,6 @@ for (const key of REQUIRED_KEYS) {
   }
 }
 
-const MIN_SECRET_LENGTH = 32;
 const PLACEHOLDER_VALUES = new Set([
   "replace_with_long_random_secret",
   "replace_with_admin_api_key"
@@ -61,10 +60,6 @@ const validateSecretLike = (name: "JWT_SECRET" | "ADMIN_API_KEY", value: string)
 
   if (PLACEHOLDER_VALUES.has(trimmed)) {
     throw new Error(`Invalid environment variable: ${name} cannot use placeholder value`);
-  }
-
-  if (trimmed.length < MIN_SECRET_LENGTH) {
-    throw new Error(`Invalid environment variable: ${name} must be at least ${MIN_SECRET_LENGTH} characters`);
   }
 
   return trimmed;

--- a/tests/config/env.test.ts
+++ b/tests/config/env.test.ts
@@ -43,6 +43,22 @@ test("env validation should reject placeholder secret values", () => {
   );
 });
 
+test("env validation should allow short jwt secret", () => {
+  const output = runEnvModule({
+    JWT_SECRET: "short-secret"
+  });
+
+  assert.match(output, /ENV_OK/);
+});
+
+test("env validation should allow short admin api key", () => {
+  const output = runEnvModule({
+    ADMIN_API_KEY: "short-admin-key"
+  });
+
+  assert.match(output, /ENV_OK/);
+});
+
 test("env validation should reject unsupported metrics cache invalidation strategy", () => {
   assert.throws(
     () =>


### PR DESCRIPTION
## 变更摘要
- 移除 `JWT_SECRET` 的最小长度校验
- 移除 `ADMIN_API_KEY` 的最小长度校验
- 保留 secret 类环境变量的非空与占位符校验
- 新增短 `JWT_SECRET` 与短 `ADMIN_API_KEY` 通过用例

## 验证
- [x] `npm test -- tests/config/env.test.ts`（150 passed, 0 failed）

Closes #67