### PR TITLE
feat: platform 接入统一会话鉴权与 RBAC 链路

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ import { createResourceAuthorizationService, type ResourceType } from "./modules
 import { hasPermissionByRole } from "./modules/authorization/rbac.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createRefreshTokenSigner, createRefreshTokenVerifier } from "./modules/auth/refresh-token.js";
-import { createSessionAuthService } from "./modules/auth/session-service.js";
+import { createSessionAuthService, type RefreshTokenRecord } from "./modules/auth/session-service.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
 import { createJwtAuthTokenSigner, createJwtAuthTokenVerifier } from "./modules/auth/session-token.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
@@ -416,7 +416,7 @@ const sessionAuthService = createSessionAuthService({
   refreshTokenSigner,
   refreshTokenVerifier,
   refreshTokenRepo: {
-    async save(record) {
+    async save(record: RefreshTokenRecord) {
       refreshTokenStore.set(record.tokenHash, {
         auth: record.auth,
         expiresAt: record.expiresAt,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "@hono/node-server";
 import { and, eq, gte, lt, ne } from "drizzle-orm";
-import { Hono } from "hono";
+import { Hono, type Context, type Next } from "hono";
 import path from "node:path";
 import { env } from "./config/env.js";
 import { db } from "./db/client.js";
@@ -26,6 +26,10 @@ import {
   teacherClassGrants,
   teacherStudentGrants
 } from "./db/schema.js";
+import {
+  createRequireAuthMiddleware,
+  createRequirePermissionFactory
+} from "./middleware/auth-session.js";
 import { createStudentAuthMiddleware } from "./middleware/auth.js";
 import { createResourceAuthorizationMiddleware } from "./middleware/resource-authorization.js";
 import { createActivityService } from "./modules/activity/service.js";
@@ -46,11 +50,18 @@ import {
   type DashboardTrendFunnelQueryInput
 } from "./modules/metrics/trend-funnel.js";
 import { createResourceAuthorizationService, type ResourceType } from "./modules/authorization/service.js";
+import { hasPermissionByRole } from "./modules/authorization/rbac.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
-import { createStudentAuthService } from "./modules/auth/service.js";
+import { createRefreshTokenSigner, createRefreshTokenVerifier } from "./modules/auth/refresh-token.js";
 import { createSessionAuthService } from "./modules/auth/session-service.js";
-import { createJwtSessionTokenManager } from "./modules/auth/session-token.js";
+import { createStudentAuthService } from "./modules/auth/service.js";
+import { createJwtAuthTokenSigner, createJwtAuthTokenVerifier } from "./modules/auth/session-token.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
+import {
+  UnifiedAuthFrozenError,
+  UnifiedAuthUnauthorizedError,
+  createUnifiedAuthService
+} from "./modules/auth/unified-service.js";
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
 import { createLikertAssessmentService } from "./modules/assessment/likert.js";
 import { createLikertAssessmentResultService } from "./modules/assessment/result.js";
@@ -70,7 +81,6 @@ import healthRoutes from "./routes/health.js";
 import { createResourcesRoutes } from "./routes/resources.js";
 import { createStudentRoutes } from "./routes/student.js";
 import { createTeacherRoutes } from "./routes/teacher.js";
-import type { SessionRefreshTokenRecord } from "./modules/auth/session.js";
 
 const studentRepo = {
   async findStudentByNo(studentNo: string) {
@@ -122,6 +132,24 @@ const studentRepo = {
   }
 };
 
+const authTokenSigner = createJwtAuthTokenSigner({
+  secret: env.JWT_SECRET,
+  expiresInDays: env.JWT_EXPIRES_IN_DAYS
+});
+
+const authTokenVerifier = createJwtAuthTokenVerifier({
+  secret: env.JWT_SECRET
+});
+
+const refreshTokenSigner = createRefreshTokenSigner({
+  secret: env.JWT_SECRET,
+  expiresInDays: 30
+});
+
+const refreshTokenVerifier = createRefreshTokenVerifier({
+  secret: env.JWT_SECRET
+});
+
 const studentAuthService = createStudentAuthService({
   studentRepo,
   passwordVerifier: bcryptPasswordVerifier,
@@ -130,6 +158,296 @@ const studentAuthService = createStudentAuthService({
     secret: env.JWT_SECRET,
     expiresInDays: env.JWT_EXPIRES_IN_DAYS
   })
+});
+
+const unifiedAuthRepo = {
+  async findByRoleAndAccount(role: "student" | "teacher", account: string) {
+    if (role === "student") {
+      const rows = await db
+        .select({
+          id: students.id,
+          studentNo: students.studentNo,
+          name: students.name,
+          passwordHash: students.passwordHash,
+          mustChangePassword: students.mustChangePassword,
+          classId: classes.id,
+          majorId: classes.majorId,
+          collegeId: colleges.id,
+          schoolId: colleges.schoolId
+        })
+        .from(students)
+        .innerJoin(classes, eq(students.classId, classes.id))
+        .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+        .where(eq(students.studentNo, account))
+        .limit(1);
+
+      if (!rows[0]) {
+        return null;
+      }
+
+      return {
+        role,
+        subjectId: String(rows[0].id),
+        account: rows[0].studentNo,
+        displayName: rows[0].name,
+        passwordHash: rows[0].passwordHash,
+        status: "active" as const,
+        mustChangePassword: rows[0].mustChangePassword,
+        studentId: rows[0].id,
+        studentNo: rows[0].studentNo,
+        scope: {
+          schoolId: rows[0].schoolId,
+          collegeId: rows[0].collegeId,
+          majorId: rows[0].majorId ?? undefined,
+          classId: rows[0].classId
+        }
+      };
+    }
+
+    const rows = await db
+      .select({
+        teacherId: teachers.teacherId,
+        name: teachers.name,
+        account: teachers.account,
+        passwordHash: teachers.passwordHash,
+        status: teachers.status
+      })
+      .from(teachers)
+      .where(eq(teachers.account, account))
+      .limit(1);
+
+    if (!rows[0]) {
+      return null;
+    }
+
+    const status: "active" | "frozen" = rows[0].status === "active" ? "active" : "frozen";
+
+    return {
+      role,
+      subjectId: rows[0].teacherId,
+      account: rows[0].account,
+      displayName: rows[0].name,
+      passwordHash: rows[0].passwordHash,
+      status,
+      mustChangePassword: false,
+      teacherId: rows[0].teacherId,
+      scope: {}
+    };
+  },
+  async findByRoleAndSubjectId(role: "student" | "teacher", subjectId: string) {
+    if (role === "student") {
+      const studentId = Number.parseInt(subjectId, 10);
+      if (!Number.isInteger(studentId) || studentId <= 0) {
+        return null;
+      }
+
+      const rows = await db
+        .select({
+          id: students.id,
+          studentNo: students.studentNo,
+          name: students.name,
+          passwordHash: students.passwordHash,
+          mustChangePassword: students.mustChangePassword,
+          classId: classes.id,
+          majorId: classes.majorId,
+          collegeId: colleges.id,
+          schoolId: colleges.schoolId
+        })
+        .from(students)
+        .innerJoin(classes, eq(students.classId, classes.id))
+        .innerJoin(colleges, eq(classes.collegeId, colleges.id))
+        .where(eq(students.id, studentId))
+        .limit(1);
+
+      if (!rows[0]) {
+        return null;
+      }
+
+      return {
+        role,
+        subjectId: String(rows[0].id),
+        account: rows[0].studentNo,
+        displayName: rows[0].name,
+        passwordHash: rows[0].passwordHash,
+        status: "active" as const,
+        mustChangePassword: rows[0].mustChangePassword,
+        studentId: rows[0].id,
+        studentNo: rows[0].studentNo,
+        scope: {
+          schoolId: rows[0].schoolId,
+          collegeId: rows[0].collegeId,
+          majorId: rows[0].majorId ?? undefined,
+          classId: rows[0].classId
+        }
+      };
+    }
+
+    const rows = await db
+      .select({
+        teacherId: teachers.teacherId,
+        name: teachers.name,
+        account: teachers.account,
+        passwordHash: teachers.passwordHash,
+        status: teachers.status
+      })
+      .from(teachers)
+      .where(eq(teachers.teacherId, subjectId))
+      .limit(1);
+
+    if (!rows[0]) {
+      return null;
+    }
+
+    const status: "active" | "frozen" = rows[0].status === "active" ? "active" : "frozen";
+
+    return {
+      role,
+      subjectId: rows[0].teacherId,
+      account: rows[0].account,
+      displayName: rows[0].name,
+      passwordHash: rows[0].passwordHash,
+      status,
+      mustChangePassword: false,
+      teacherId: rows[0].teacherId,
+      scope: {}
+    };
+  },
+  async updatePassword({
+    role,
+    subjectId,
+    passwordHash,
+    mustChangePassword
+  }: {
+    role: "student" | "teacher";
+    subjectId: string;
+    passwordHash: string;
+    mustChangePassword: boolean;
+  }) {
+    if (role === "student") {
+      const studentId = Number.parseInt(subjectId, 10);
+      if (!Number.isInteger(studentId) || studentId <= 0) {
+        return;
+      }
+
+      await db
+        .update(students)
+        .set({
+          passwordHash,
+          passwordUpdatedAt: new Date(),
+          mustChangePassword
+        })
+        .where(eq(students.id, studentId));
+      return;
+    }
+
+    await db
+      .update(teachers)
+      .set({
+        passwordHash
+      })
+      .where(eq(teachers.teacherId, subjectId));
+  }
+};
+
+const unifiedAuthService = createUnifiedAuthService({
+  authRepo: unifiedAuthRepo,
+  passwordVerifier: bcryptPasswordVerifier,
+  passwordHasher: bcryptPasswordHasher,
+  tokenSigner: authTokenSigner,
+  adminAccount: {
+    account: "admin",
+    password: env.ADMIN_API_KEY
+  }
+});
+
+const refreshTokenStore = new Map<
+  string,
+  {
+    auth: import("./modules/auth/session-token.js").AuthTokenPayload;
+    expiresAt: Date;
+    revokedAt: Date | null;
+    createdAt: Date;
+  }
+>();
+
+const sessionAuthService = createSessionAuthService({
+  authenticator: {
+    async loginByAccount(account, password) {
+      const normalizedAccount = account.trim();
+      let frozenError: UnifiedAuthFrozenError | null = null;
+
+      for (const role of ["admin", "teacher", "student"] as const) {
+        try {
+          const loginResult = await unifiedAuthService.login({
+            role,
+            account: normalizedAccount,
+            password
+          });
+
+          const verifiedPayload = authTokenVerifier.verifyAuthToken(loginResult.token);
+          if (!verifiedPayload) {
+            throw new UnifiedAuthUnauthorizedError();
+          }
+
+          return verifiedPayload;
+        } catch (error) {
+          if (error instanceof UnifiedAuthFrozenError) {
+            frozenError = error;
+            continue;
+          }
+
+          if (error instanceof UnifiedAuthUnauthorizedError) {
+            continue;
+          }
+
+          throw error;
+        }
+      }
+
+      if (frozenError) {
+        throw frozenError;
+      }
+
+      throw new UnifiedAuthUnauthorizedError();
+    }
+  },
+  authTokenSigner,
+  authTokenVerifier,
+  refreshTokenSigner,
+  refreshTokenVerifier,
+  refreshTokenRepo: {
+    async save(record) {
+      refreshTokenStore.set(record.tokenHash, {
+        auth: record.auth,
+        expiresAt: record.expiresAt,
+        revokedAt: record.revokedAt,
+        createdAt: record.createdAt
+      });
+    },
+    async findByTokenHash(tokenHash) {
+      const found = refreshTokenStore.get(tokenHash);
+      if (!found) {
+        return null;
+      }
+      return {
+        tokenHash,
+        auth: found.auth,
+        expiresAt: found.expiresAt,
+        revokedAt: found.revokedAt,
+        createdAt: found.createdAt
+      };
+    },
+    async revokeByTokenHash(tokenHash, revokedAt) {
+      const existing = refreshTokenStore.get(tokenHash);
+      if (!existing) {
+        return;
+      }
+      refreshTokenStore.set(tokenHash, {
+        ...existing,
+        revokedAt
+      });
+    }
+  }
 });
 
 const studentFirstLoginVerificationRepo = {
@@ -652,117 +970,33 @@ const teacherActivityExecutionService = createTeacherActivityExecutionService({
   teacherActivityExecutionRepo
 });
 
-const SESSION_ADMIN_ACCOUNT = "admin";
-const SESSION_ADMIN_USER_ID = "admin:root";
-const sessionRefreshTokenStore = new Map<string, SessionRefreshTokenRecord>();
-
-const sessionAccountRepo = {
-  async findByAccount(account: string) {
-    const normalizedAccount = account.trim();
-    if (!normalizedAccount) {
-      return null;
-    }
-
-    if (normalizedAccount === SESSION_ADMIN_ACCOUNT) {
-      const passwordHash = await bcryptPasswordHasher.hash(env.ADMIN_API_KEY);
-      return {
-        userId: SESSION_ADMIN_USER_ID,
-        role: "admin" as const,
-        account: SESSION_ADMIN_ACCOUNT,
-        name: "系统管理员",
-        passwordHash,
-        status: "active" as const
-      };
-    }
-
-    const teacherRows = await db
-      .select({
-        teacherId: teachers.teacherId,
-        account: teachers.account,
-        name: teachers.name,
-        passwordHash: teachers.passwordHash,
-        status: teachers.status
-      })
-      .from(teachers)
-      .where(eq(teachers.account, normalizedAccount))
-      .limit(1);
-    const teacher = teacherRows[0];
-
-    if (teacher) {
-      return {
-        userId: `teacher:${teacher.teacherId}`,
-        role: "teacher" as const,
-        account: teacher.account,
-        name: teacher.name,
-        teacherId: teacher.teacherId,
-        passwordHash: teacher.passwordHash,
-        status: teacher.status === "frozen" ? "frozen" : "active"
-      };
-    }
-
-    const studentRows = await db
-      .select({
-        id: students.id,
-        studentNo: students.studentNo,
-        name: students.name,
-        passwordHash: students.passwordHash
-      })
-      .from(students)
-      .where(eq(students.studentNo, normalizedAccount))
-      .limit(1);
-    const student = studentRows[0];
-
-    if (!student) {
-      return null;
-    }
-
-    return {
-      userId: `student:${student.id}`,
-      role: "student" as const,
-      account: student.studentNo,
-      name: student.name,
-      studentId: student.id,
-      studentNo: student.studentNo,
-      passwordHash: student.passwordHash,
-      status: "active" as const
-    };
-  }
-};
-
-const sessionRefreshTokenRepo = {
-  async save(record: SessionRefreshTokenRecord) {
-    sessionRefreshTokenStore.set(record.tokenHash, record);
-  },
-  async findByTokenHash(tokenHash: string) {
-    return sessionRefreshTokenStore.get(tokenHash) ?? null;
-  },
-  async revokeByTokenHash(tokenHash: string, revokedAt: Date) {
-    const existing = sessionRefreshTokenStore.get(tokenHash);
-    if (!existing) {
-      return;
-    }
-
-    sessionRefreshTokenStore.set(tokenHash, {
-      ...existing,
-      revokedAt
-    });
-  }
-};
-
-const sessionAuthService = createSessionAuthService({
-  accountRepo: sessionAccountRepo,
-  refreshTokenRepo: sessionRefreshTokenRepo,
-  passwordVerifier: bcryptPasswordVerifier,
-  tokenManager: createJwtSessionTokenManager({
-    secret: env.JWT_SECRET
-  })
-});
-
 const requireStudentAuth = createStudentAuthMiddleware({
   tokenVerifier: createJwtTokenVerifier({
     secret: env.JWT_SECRET
   }),
   studentRepo
+});
+
+const requireAuth = createRequireAuthMiddleware({
+  tokenVerifier: authTokenVerifier
+});
+
+const hasPermission = ({
+  auth,
+  permission
+}: {
+  auth: import("./modules/auth/session-token.js").AuthTokenPayload;
+  permission: string;
+}): boolean => {
+  return hasPermissionByRole({
+    role: auth.role,
+    permission
+  });
+};
+
+const requirePermission = createRequirePermissionFactory({
+  tokenVerifier: authTokenVerifier,
+  permissionChecker: ({ auth, permission }) => hasPermission({ auth, permission })
 });
 
 const authorizationRepo = {
@@ -1504,11 +1738,26 @@ const certificateUploadService = createCertificateUploadService({
   uploadDir: path.resolve(process.cwd(), "uploads/certificates")
 });
 
-const createResourceAuthorization = (resourceType: ResourceType) =>
-  createResourceAuthorizationMiddleware({
+const createResourceAuthorization = (resourceType: ResourceType) => {
+  const authorizeResource = createResourceAuthorizationMiddleware({
     resourceType,
-    authorizationService: resourceAuthorizationService
+    authorizationService: resourceAuthorizationService,
+    hasPermission: ({ auth, permission }) => hasPermission({ auth, permission })
   });
+
+  return async (c: Context, next: Next) => {
+    let passedAuth = false;
+    await requireAuth(c, async () => {
+      passedAuth = true;
+    });
+
+    if (!passedAuth) {
+      return;
+    }
+
+    await authorizeResource(c, next);
+  };
+};
 
 const app = new Hono();
 
@@ -1524,10 +1773,12 @@ app.route(
   "/auth",
   createAuthRoutes({
     studentAuthService,
-    sessionAuthService,
     studentFirstLoginVerificationService,
     enrollmentProfileService,
-    requireStudentAuth
+    sessionAuthService,
+    unifiedAuthService,
+    requireStudentAuth,
+    requireAuth
   })
 );
 app.route(
@@ -1543,7 +1794,11 @@ app.route(
     adminOrgService,
     teacherAccountService,
     adminStudentArchiveService,
-    adminApiKey: env.ADMIN_API_KEY
+    requirePermission,
+    resolveOperatorId: (c) => {
+      const auth = c.get("auth");
+      return auth?.sub ?? "system-admin";
+    }
   })
 );
 app.route("/resources", createResourcesRoutes({ createResourceAuthorization }));
@@ -1552,7 +1807,15 @@ app.route(
   createTeacherRoutes({
     teacherMyStudentsService,
     teacherStudentDetailService,
-    teacherActivityExecutionService
+    teacherActivityExecutionService,
+    requirePermission,
+    resolveTeacherId: (c) => {
+      const auth = c.get("auth");
+      if (!auth || auth.role !== "teacher") {
+        return null;
+      }
+      return auth.teacherId ?? null;
+    }
   })
 );
 app.route(

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import {
 import { createResourceAuthorizationService, type ResourceType } from "./modules/authorization/service.js";
 import { bcryptPasswordHasher, bcryptPasswordVerifier } from "./modules/auth/password.js";
 import { createStudentAuthService } from "./modules/auth/service.js";
+import { createSessionAuthService } from "./modules/auth/session-service.js";
+import { createJwtSessionTokenManager } from "./modules/auth/session-token.js";
 import { createJwtTokenSigner, createJwtTokenVerifier } from "./modules/auth/token.js";
 import { createStudentFirstLoginVerificationService } from "./modules/auth/first-login-verification.js";
 import { createLikertAssessmentService } from "./modules/assessment/likert.js";
@@ -68,6 +70,7 @@ import healthRoutes from "./routes/health.js";
 import { createResourcesRoutes } from "./routes/resources.js";
 import { createStudentRoutes } from "./routes/student.js";
 import { createTeacherRoutes } from "./routes/teacher.js";
+import type { SessionRefreshTokenRecord } from "./modules/auth/session.js";
 
 const studentRepo = {
   async findStudentByNo(studentNo: string) {
@@ -647,6 +650,112 @@ const teacherActivityExecutionRepo = {
 
 const teacherActivityExecutionService = createTeacherActivityExecutionService({
   teacherActivityExecutionRepo
+});
+
+const SESSION_ADMIN_ACCOUNT = "admin";
+const SESSION_ADMIN_USER_ID = "admin:root";
+const sessionRefreshTokenStore = new Map<string, SessionRefreshTokenRecord>();
+
+const sessionAccountRepo = {
+  async findByAccount(account: string) {
+    const normalizedAccount = account.trim();
+    if (!normalizedAccount) {
+      return null;
+    }
+
+    if (normalizedAccount === SESSION_ADMIN_ACCOUNT) {
+      const passwordHash = await bcryptPasswordHasher.hash(env.ADMIN_API_KEY);
+      return {
+        userId: SESSION_ADMIN_USER_ID,
+        role: "admin" as const,
+        account: SESSION_ADMIN_ACCOUNT,
+        name: "系统管理员",
+        passwordHash,
+        status: "active" as const
+      };
+    }
+
+    const teacherRows = await db
+      .select({
+        teacherId: teachers.teacherId,
+        account: teachers.account,
+        name: teachers.name,
+        passwordHash: teachers.passwordHash,
+        status: teachers.status
+      })
+      .from(teachers)
+      .where(eq(teachers.account, normalizedAccount))
+      .limit(1);
+    const teacher = teacherRows[0];
+
+    if (teacher) {
+      return {
+        userId: `teacher:${teacher.teacherId}`,
+        role: "teacher" as const,
+        account: teacher.account,
+        name: teacher.name,
+        teacherId: teacher.teacherId,
+        passwordHash: teacher.passwordHash,
+        status: teacher.status === "frozen" ? "frozen" : "active"
+      };
+    }
+
+    const studentRows = await db
+      .select({
+        id: students.id,
+        studentNo: students.studentNo,
+        name: students.name,
+        passwordHash: students.passwordHash
+      })
+      .from(students)
+      .where(eq(students.studentNo, normalizedAccount))
+      .limit(1);
+    const student = studentRows[0];
+
+    if (!student) {
+      return null;
+    }
+
+    return {
+      userId: `student:${student.id}`,
+      role: "student" as const,
+      account: student.studentNo,
+      name: student.name,
+      studentId: student.id,
+      studentNo: student.studentNo,
+      passwordHash: student.passwordHash,
+      status: "active" as const
+    };
+  }
+};
+
+const sessionRefreshTokenRepo = {
+  async save(record: SessionRefreshTokenRecord) {
+    sessionRefreshTokenStore.set(record.tokenHash, record);
+  },
+  async findByTokenHash(tokenHash: string) {
+    return sessionRefreshTokenStore.get(tokenHash) ?? null;
+  },
+  async revokeByTokenHash(tokenHash: string, revokedAt: Date) {
+    const existing = sessionRefreshTokenStore.get(tokenHash);
+    if (!existing) {
+      return;
+    }
+
+    sessionRefreshTokenStore.set(tokenHash, {
+      ...existing,
+      revokedAt
+    });
+  }
+};
+
+const sessionAuthService = createSessionAuthService({
+  accountRepo: sessionAccountRepo,
+  refreshTokenRepo: sessionRefreshTokenRepo,
+  passwordVerifier: bcryptPasswordVerifier,
+  tokenManager: createJwtSessionTokenManager({
+    secret: env.JWT_SECRET
+  })
 });
 
 const requireStudentAuth = createStudentAuthMiddleware({
@@ -1415,6 +1524,7 @@ app.route(
   "/auth",
   createAuthRoutes({
     studentAuthService,
+    sessionAuthService,
     studentFirstLoginVerificationService,
     enrollmentProfileService,
     requireStudentAuth

--- a/src/middleware/auth-session.ts
+++ b/src/middleware/auth-session.ts
@@ -1,0 +1,144 @@
+import type { Context, MiddlewareHandler } from "hono";
+import type { AuthRole, AuthTokenPayload, AuthTokenVerifier } from "../modules/auth/session-token.js";
+
+declare module "hono" {
+  interface ContextVariableMap {
+    auth: AuthTokenPayload;
+  }
+}
+
+const BEARER_TOKEN_PATTERN = /^bearer\s+(\S+)\s*$/i;
+
+const parseBearerToken = (authorizationHeader: string | undefined): string | null => {
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const matched = authorizationHeader.trim().match(BEARER_TOKEN_PATTERN);
+  if (!matched) {
+    return null;
+  }
+
+  return matched[1];
+};
+
+export const createRequireAuthMiddleware = ({
+  tokenVerifier
+}: {
+  tokenVerifier: AuthTokenVerifier;
+}): MiddlewareHandler => {
+  return async (c, next) => {
+    const token = parseBearerToken(c.req.header("authorization"));
+    if (!token) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const verified = tokenVerifier.verifyAuthToken(token);
+    if (!verified) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    c.set("auth", verified);
+    await next();
+  };
+};
+
+export const createRequireRoleMiddleware = ({
+  tokenVerifier,
+  roles
+}: {
+  tokenVerifier: AuthTokenVerifier;
+  roles: AuthRole[];
+}): MiddlewareHandler => {
+  const requireAuth = createRequireAuthMiddleware({ tokenVerifier });
+
+  return async (c, next) => {
+    let passedAuth = false;
+    await requireAuth(c, async () => {
+      passedAuth = true;
+    });
+
+    if (!passedAuth) {
+      return;
+    }
+
+    const auth = c.get("auth");
+    if (!auth || !roles.includes(auth.role)) {
+      c.status(403);
+      c.json({ message: "forbidden" });
+      return;
+    }
+
+    await next();
+  };
+};
+
+export type PermissionChecker = (input: {
+  auth: AuthTokenPayload;
+  permission: string;
+}) => boolean;
+
+export const createRequirePermissionFactory = ({
+  tokenVerifier,
+  permissionChecker
+}: {
+  tokenVerifier: AuthTokenVerifier;
+  permissionChecker: PermissionChecker;
+}): ((permission: string) => MiddlewareHandler) => {
+  const requireAuth = createRequireAuthMiddleware({ tokenVerifier });
+
+  return (permission: string) => {
+    return async (c, next) => {
+      let passedAuth = false;
+      await requireAuth(c, async () => {
+        passedAuth = true;
+      });
+
+      if (!passedAuth) {
+        return;
+      }
+
+      const auth = c.get("auth");
+      if (!auth || !permissionChecker({ auth, permission })) {
+        return c.json({ message: "forbidden" }, 403);
+      }
+
+      await next();
+    };
+  };
+};
+
+export type ScopeChecker = (input: {
+  auth: AuthTokenPayload;
+  context: Context;
+}) => boolean | Promise<boolean>;
+
+export const createRequireScopeFactory = ({
+  tokenVerifier,
+  scopeChecker
+}: {
+  tokenVerifier: AuthTokenVerifier;
+  scopeChecker: ScopeChecker;
+}): (() => MiddlewareHandler) => {
+  const requireAuth = createRequireAuthMiddleware({ tokenVerifier });
+
+  return () => {
+    return async (c, next) => {
+      let passedAuth = false;
+      await requireAuth(c, async () => {
+        passedAuth = true;
+      });
+
+      if (!passedAuth) {
+        return;
+      }
+
+      const auth = c.get("auth");
+      if (!auth || !(await scopeChecker({ auth, context: c }))) {
+        return c.json({ message: "forbidden" }, 403);
+      }
+
+      await next();
+    };
+  };
+};

--- a/src/middleware/resource-authorization.ts
+++ b/src/middleware/resource-authorization.ts
@@ -1,11 +1,13 @@
 import type { MiddlewareHandler } from "hono";
+import type { AuthTokenPayload } from "../modules/auth/session-token.js";
 import type {
   ResourceAuthorizationService,
   ResourceType
 } from "../modules/authorization/service.js";
 
 export interface AuthorizedResourceContext {
-  teacherId: string;
+  role: AuthTokenPayload["role"];
+  teacherId?: string;
   studentId: number;
   resourceType: ResourceType;
   resourceId: number;
@@ -20,16 +22,8 @@ declare module "hono" {
 export interface CreateResourceAuthorizationMiddlewareInput {
   resourceType: ResourceType;
   authorizationService: ResourceAuthorizationService;
+  hasPermission: (input: { auth: AuthTokenPayload; permission: string }) => boolean;
 }
-
-const parseTeacherId = (rawTeacherId: string | undefined): string | null => {
-  if (!rawTeacherId) {
-    return null;
-  }
-
-  const teacherId = rawTeacherId.trim();
-  return teacherId.length > 0 ? teacherId : null;
-};
 
 const parseResourceId = (rawResourceId: string | undefined): number | null => {
   if (!rawResourceId) {
@@ -45,14 +39,29 @@ const parseResourceId = (rawResourceId: string | undefined): number | null => {
   return parsed;
 };
 
+const resolveResourcePermission = (resourceType: ResourceType): string => {
+  switch (resourceType) {
+    case "report":
+      return "report.read";
+    case "task":
+      return "task.read";
+    case "certificate":
+      return "task.read";
+    case "profile":
+      return "student.profile.read";
+    default:
+      return "report.read";
+  }
+};
+
 export const createResourceAuthorizationMiddleware = ({
   resourceType,
-  authorizationService
+  authorizationService,
+  hasPermission
 }: CreateResourceAuthorizationMiddlewareInput): MiddlewareHandler => {
   return async (c, next) => {
-    const teacherId = parseTeacherId(c.req.header("x-teacher-id"));
-
-    if (!teacherId) {
+    const auth = c.get("auth");
+    if (!auth) {
       return c.json({ message: "unauthorized" }, 401);
     }
 
@@ -61,23 +70,67 @@ export const createResourceAuthorizationMiddleware = ({
       return c.json({ message: "invalid resource id" }, 400);
     }
 
-    const decision = await authorizationService.authorizeTeacherResource({
-      teacherId,
+    if (!hasPermission({ auth, permission: resolveResourcePermission(resourceType) })) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+
+    const studentId = await authorizationService.findResourceStudentId({
       resourceType,
       resourceId
     });
 
-    if (decision.status === "not_found") {
+    if (!studentId) {
       return c.json({ message: "resource not found" }, 404);
     }
 
-    if (decision.status === "forbidden") {
-      return c.json({ message: "forbidden" }, 403);
+    if (auth.role === "student") {
+      if (!auth.studentId || auth.studentId !== studentId) {
+        return c.json({ message: "forbidden" }, 403);
+      }
+
+      c.set("resourceAuth", {
+        role: auth.role,
+        studentId,
+        resourceType,
+        resourceId
+      });
+      await next();
+      return;
+    }
+
+    if (auth.role === "teacher") {
+      if (!auth.teacherId) {
+        return c.json({ message: "forbidden" }, 403);
+      }
+
+      const decision = await authorizationService.authorizeTeacherResource({
+        teacherId: auth.teacherId,
+        resourceType,
+        resourceId
+      });
+
+      if (decision.status === "not_found") {
+        return c.json({ message: "resource not found" }, 404);
+      }
+
+      if (decision.status === "forbidden") {
+        return c.json({ message: "forbidden" }, 403);
+      }
+
+      c.set("resourceAuth", {
+        role: auth.role,
+        teacherId: auth.teacherId,
+        studentId: decision.studentId,
+        resourceType,
+        resourceId
+      });
+      await next();
+      return;
     }
 
     c.set("resourceAuth", {
-      teacherId,
-      studentId: decision.studentId,
+      role: auth.role,
+      studentId,
       resourceType,
       resourceId
     });

--- a/src/modules/assessment/result.ts
+++ b/src/modules/assessment/result.ts
@@ -156,7 +156,8 @@ export const createLikertAssessmentResultService = ({
         { direction: "employment", score: employment },
         { direction: "postgraduate", score: postgraduate },
         { direction: "civil_service", score: civilService }
-      ].sort((left, right) => right.score - left.score);
+      ];
+      scores.sort((left, right) => right.score - left.score);
 
       const recommendationDirection = scores[0]?.direction ?? "employment";
 

--- a/src/modules/auth/refresh-token.ts
+++ b/src/modules/auth/refresh-token.ts
@@ -1,0 +1,172 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import type { AuthRole, AuthTokenPayload } from "./session-token.js";
+
+const require = createRequire(import.meta.url);
+const jwt = require("jsonwebtoken") as {
+  sign(payload: Record<string, unknown>, secret: string, options: { expiresIn: number }): string;
+  verify(token: string, secret: string): string | Record<string, unknown>;
+};
+
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+interface RefreshTokenJwtPayload {
+  sub: string;
+  role: AuthRole;
+  account: string;
+  jti: string;
+  tokenType: "refresh";
+  displayName?: string;
+  studentId?: number;
+  studentNo?: string;
+  teacherId?: string;
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+  mustChangePassword?: boolean;
+  exp?: number;
+}
+
+export interface VerifiedRefreshTokenPayload {
+  jti: string;
+  auth: AuthTokenPayload;
+  expiresAt: Date;
+}
+
+export interface RefreshTokenSigner {
+  expiresIn: number;
+  signRefreshToken(auth: AuthTokenPayload): string;
+}
+
+export interface RefreshTokenVerifier {
+  verifyRefreshToken(token: string): VerifiedRefreshTokenPayload | null;
+}
+
+const toPositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
+};
+
+const toDecodedRefreshPayload = (
+  payload: string | Record<string, unknown>
+): RefreshTokenJwtPayload | null => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const sub = payload.sub;
+  const role = payload.role;
+  const account = payload.account;
+  const jti = payload.jti;
+  const tokenType = payload.tokenType;
+  const exp = payload.exp;
+
+  if (
+    typeof sub !== "string" ||
+    (role !== "student" && role !== "teacher" && role !== "admin") ||
+    typeof account !== "string" ||
+    typeof jti !== "string" ||
+    tokenType !== "refresh" ||
+    typeof exp !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    sub,
+    role,
+    account,
+    jti,
+    tokenType: "refresh",
+    exp,
+    displayName: typeof payload.displayName === "string" ? payload.displayName : undefined,
+    studentId: toPositiveInteger(payload.studentId),
+    studentNo: typeof payload.studentNo === "string" ? payload.studentNo : undefined,
+    teacherId: typeof payload.teacherId === "string" ? payload.teacherId : undefined,
+    schoolId: toPositiveInteger(payload.schoolId),
+    collegeId: toPositiveInteger(payload.collegeId),
+    majorId: toPositiveInteger(payload.majorId),
+    classId: toPositiveInteger(payload.classId),
+    mustChangePassword: typeof payload.mustChangePassword === "boolean" ? payload.mustChangePassword : undefined
+  };
+};
+
+export const createRefreshTokenSigner = ({
+  secret,
+  expiresInDays
+}: {
+  secret: string;
+  expiresInDays: number;
+}): RefreshTokenSigner => {
+  const expiresIn = expiresInDays * SECONDS_PER_DAY;
+
+  return {
+    expiresIn,
+    signRefreshToken(auth) {
+      const payload: Record<string, unknown> = {
+        sub: auth.sub,
+        role: auth.role,
+        account: auth.account,
+        tokenType: "refresh",
+        jti: randomUUID()
+      };
+
+      if (auth.displayName) payload.displayName = auth.displayName;
+      if (auth.studentId) payload.studentId = auth.studentId;
+      if (auth.studentNo) payload.studentNo = auth.studentNo;
+      if (auth.teacherId) payload.teacherId = auth.teacherId;
+      if (auth.schoolId) payload.schoolId = auth.schoolId;
+      if (auth.collegeId) payload.collegeId = auth.collegeId;
+      if (auth.majorId) payload.majorId = auth.majorId;
+      if (auth.classId) payload.classId = auth.classId;
+      if (typeof auth.mustChangePassword === "boolean") payload.mustChangePassword = auth.mustChangePassword;
+
+      return jwt.sign(payload, secret, { expiresIn });
+    }
+  };
+};
+
+export const createRefreshTokenVerifier = ({
+  secret
+}: {
+  secret: string;
+}): RefreshTokenVerifier => {
+  return {
+    verifyRefreshToken(token) {
+      try {
+        const decoded = toDecodedRefreshPayload(jwt.verify(token, secret));
+        if (!decoded) {
+          return null;
+        }
+
+        return {
+          jti: decoded.jti,
+          auth: {
+            sub: decoded.sub,
+            role: decoded.role,
+            account: decoded.account,
+            displayName: decoded.displayName,
+            studentId: decoded.studentId,
+            studentNo: decoded.studentNo,
+            teacherId: decoded.teacherId,
+            schoolId: decoded.schoolId,
+            collegeId: decoded.collegeId,
+            majorId: decoded.majorId,
+            classId: decoded.classId,
+            mustChangePassword: decoded.mustChangePassword
+          },
+          expiresAt: new Date(decoded.exp! * 1000)
+        };
+      } catch {
+        return null;
+      }
+    }
+  };
+};
+
+export const hashRefreshToken = (token: string): string => {
+  return createHash("sha256").update(token).digest("hex");
+};

--- a/src/modules/auth/session-service.ts
+++ b/src/modules/auth/session-service.ts
@@ -1,0 +1,183 @@
+import { createHash } from "node:crypto";
+import type {
+  CreateSessionAuthServiceInput,
+  SessionAuthResult,
+  SessionRefreshTokenRecord,
+  SessionUserView
+} from "./session.js";
+import { SessionAuthUnauthorizedError } from "./session.js";
+
+const DUMMY_PASSWORD_HASH = "$2b$10$ykqJ8CfeprKl2UpQm9a7ZOv9wZWyG2J.AoPTB5oTvbGdZyc/Ljcsm";
+
+const hasUsablePasswordHash = (passwordHash: string | null): passwordHash is string => {
+  return typeof passwordHash === "string" && passwordHash.trim().length > 0;
+};
+
+const hashRefreshToken = (token: string): string => {
+  return createHash("sha256").update(token).digest("hex");
+};
+
+const toSessionUserView = (account: {
+  userId: string;
+  role: "admin" | "teacher" | "student";
+  account: string;
+  name: string;
+  teacherId?: string;
+  studentId?: number;
+  studentNo?: string;
+}): SessionUserView => {
+  return {
+    userId: account.userId,
+    role: account.role,
+    account: account.account,
+    name: account.name,
+    teacherId: account.teacherId,
+    studentId: account.studentId,
+    studentNo: account.studentNo
+  };
+};
+
+const toSessionAuthResult = ({
+  user,
+  pair
+}: {
+  user: SessionUserView;
+  pair: {
+    accessToken: string;
+    refreshToken: string;
+    accessExpiresIn: number;
+    refreshExpiresIn: number;
+  };
+}): SessionAuthResult => {
+  return {
+    accessToken: pair.accessToken,
+    refreshToken: pair.refreshToken,
+    expiresIn: pair.accessExpiresIn,
+    refreshExpiresIn: pair.refreshExpiresIn,
+    user
+  };
+};
+
+const isSessionUserSame = (left: SessionUserView, right: SessionUserView): boolean => {
+  return left.userId === right.userId && left.role === right.role && left.account === right.account;
+};
+
+const isRefreshRecordActive = (record: SessionRefreshTokenRecord, now: Date): boolean => {
+  if (record.revokedAt) {
+    return false;
+  }
+
+  return record.expiresAt.getTime() > now.getTime();
+};
+
+const buildRefreshRecord = ({
+  tokenHash,
+  user,
+  refreshExpiresAt,
+  now
+}: {
+  tokenHash: string;
+  user: SessionUserView;
+  refreshExpiresAt: Date;
+  now: Date;
+}): SessionRefreshTokenRecord => {
+  return {
+    tokenHash,
+    user,
+    createdAt: now,
+    expiresAt: refreshExpiresAt,
+    revokedAt: null
+  };
+};
+
+export const createSessionAuthService = ({
+  accountRepo,
+  refreshTokenRepo,
+  passwordVerifier,
+  tokenManager
+}: CreateSessionAuthServiceInput) => {
+  return {
+    async login({ account, password }) {
+      const normalizedAccount = account.trim();
+      const accountRecord = await accountRepo.findByAccount(normalizedAccount);
+      const passwordHashForCompare = hasUsablePasswordHash(accountRecord?.passwordHash ?? null)
+        ? accountRecord!.passwordHash
+        : DUMMY_PASSWORD_HASH;
+      const passwordMatched = await passwordVerifier.compare(password, passwordHashForCompare);
+      const isFrozen = accountRecord?.status === "frozen";
+
+      if (!accountRecord || !hasUsablePasswordHash(accountRecord.passwordHash) || !passwordMatched || isFrozen) {
+        throw new SessionAuthUnauthorizedError();
+      }
+
+      const user = toSessionUserView(accountRecord);
+      const tokenPair = tokenManager.createTokenPair(user);
+      const tokenHash = hashRefreshToken(tokenPair.refreshToken);
+      const now = new Date();
+
+      await refreshTokenRepo.save(
+        buildRefreshRecord({
+          tokenHash,
+          user,
+          refreshExpiresAt: tokenPair.refreshExpiresAt,
+          now
+        })
+      );
+
+      return toSessionAuthResult({
+        user,
+        pair: tokenPair
+      });
+    },
+    async refresh({ refreshToken }) {
+      const verifiedToken = tokenManager.verifyRefreshToken(refreshToken);
+      if (!verifiedToken) {
+        throw new SessionAuthUnauthorizedError();
+      }
+
+      const now = new Date();
+      const refreshTokenHash = hashRefreshToken(refreshToken);
+      const existingRecord = await refreshTokenRepo.findByTokenHash(refreshTokenHash);
+
+      if (!existingRecord || !isRefreshRecordActive(existingRecord, now)) {
+        throw new SessionAuthUnauthorizedError();
+      }
+
+      if (!isSessionUserSame(existingRecord.user, verifiedToken.user)) {
+        throw new SessionAuthUnauthorizedError();
+      }
+
+      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
+
+      const tokenPair = tokenManager.createTokenPair(verifiedToken.user);
+      const nextTokenHash = hashRefreshToken(tokenPair.refreshToken);
+
+      await refreshTokenRepo.save(
+        buildRefreshRecord({
+          tokenHash: nextTokenHash,
+          user: verifiedToken.user,
+          refreshExpiresAt: tokenPair.refreshExpiresAt,
+          now
+        })
+      );
+
+      return toSessionAuthResult({
+        user: verifiedToken.user,
+        pair: tokenPair
+      });
+    },
+    async logout({ refreshToken }) {
+      const now = new Date();
+      const refreshTokenHash = hashRefreshToken(refreshToken);
+      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
+    },
+    async getSessionUser({ accessToken }) {
+      const user = tokenManager.verifyAccessToken(accessToken);
+      if (!user) {
+        throw new SessionAuthUnauthorizedError();
+      }
+
+      return user;
+    }
+  };
+};

--- a/src/modules/auth/session-service.ts
+++ b/src/modules/auth/session-service.ts
@@ -1,10 +1,22 @@
+import { createHash } from "node:crypto";
+import type { PasswordVerifier } from "./password.js";
 import type { AuthTokenPayload, AuthTokenSigner, AuthTokenVerifier } from "./session-token.js";
+import type {
+  CreateSessionAuthServiceInput as LegacyCreateSessionAuthServiceInput,
+  SessionAccountRecord,
+  SessionAuthService as LegacySessionAuthService,
+  SessionRefreshTokenRecord,
+  SessionUserView
+} from "./session.js";
+import { SessionAuthUnauthorizedError } from "./session.js";
 import type {
   RefreshTokenSigner,
   RefreshTokenVerifier,
   VerifiedRefreshTokenPayload
 } from "./refresh-token.js";
 import { hashRefreshToken } from "./refresh-token.js";
+
+const DUMMY_PASSWORD_HASH = "$2b$10$ykqJ8CfeprKl2UpQm9a7ZOv9wZWyG2J.AoPTB5oTvbGdZyc/Ljcsm";
 
 export interface SessionLoginResult {
   accessToken: string;
@@ -15,15 +27,20 @@ export interface SessionLoginResult {
     userId: string;
     role: AuthTokenPayload["role"];
     displayName: string;
+    name?: string;
     account: string;
+    teacherId?: string;
+    studentId?: number;
+    studentNo?: string;
   };
 }
 
 export interface SessionAuthService {
   login(input: { account: string; password: string }): Promise<SessionLoginResult>;
-  refresh(refreshToken: string): Promise<SessionLoginResult>;
-  logout(refreshToken: string): Promise<void>;
+  refresh(input: string | { refreshToken: string }): Promise<SessionLoginResult>;
+  logout(input: string | { refreshToken: string }): Promise<void>;
   me(accessToken: string): Promise<AuthTokenPayload>;
+  getSessionUser?(input: { accessToken: string }): Promise<SessionUserView>;
 }
 
 export interface SessionAuthenticator {
@@ -44,19 +61,56 @@ export interface RefreshTokenRepository {
   revokeByTokenHash(tokenHash: string, revokedAt: Date): Promise<void>;
 }
 
-export class SessionUnauthorizedError extends Error {
+export class SessionUnauthorizedError extends SessionAuthUnauthorizedError {
   constructor() {
-    super("unauthorized");
+    super();
     this.name = "SessionUnauthorizedError";
   }
 }
 
-const toPublicUser = (auth: AuthTokenPayload) => ({
+interface ModernCreateSessionAuthServiceInput {
+  authenticator: SessionAuthenticator;
+  authTokenSigner: AuthTokenSigner;
+  authTokenVerifier: AuthTokenVerifier;
+  refreshTokenSigner: RefreshTokenSigner;
+  refreshTokenVerifier: RefreshTokenVerifier;
+  refreshTokenRepo: RefreshTokenRepository;
+}
+
+const toPublicUser = (auth: AuthTokenPayload): SessionLoginResult["user"] => ({
   userId: auth.sub,
   role: auth.role,
   displayName: auth.displayName ?? auth.account,
-  account: auth.account
+  name: auth.displayName ?? auth.account,
+  account: auth.account,
+  teacherId: auth.teacherId,
+  studentId: auth.studentId,
+  studentNo: auth.studentNo
 });
+
+const toAuthPayloadFromSessionUser = (user: SessionUserView): AuthTokenPayload => ({
+  sub: user.userId,
+  role: user.role,
+  account: user.account,
+  displayName: user.name,
+  teacherId: user.teacherId,
+  studentId: user.studentId,
+  studentNo: user.studentNo
+});
+
+const toSessionUserFromAuthPayload = (auth: AuthTokenPayload): SessionUserView => ({
+  userId: auth.sub,
+  role: auth.role,
+  account: auth.account,
+  name: auth.displayName ?? auth.account,
+  teacherId: auth.teacherId,
+  studentId: auth.studentId,
+  studentNo: auth.studentNo
+});
+
+const resolveRefreshToken = (input: string | { refreshToken: string }): string => {
+  return typeof input === "string" ? input : input.refreshToken;
+};
 
 const isRefreshTokenRecordActive = (record: RefreshTokenRecord, now: Date): boolean => {
   if (record.revokedAt) {
@@ -77,31 +131,199 @@ const buildRefreshRecord = ({
   refreshToken: string;
   verifiedRefreshToken: VerifiedRefreshTokenPayload;
   now: Date;
-}): RefreshTokenRecord => {
+}): RefreshTokenRecord => ({
+  tokenHash: hashRefreshToken(refreshToken),
+  auth: verifiedRefreshToken.auth,
+  expiresAt: verifiedRefreshToken.expiresAt,
+  revokedAt: null,
+  createdAt: now
+});
+
+const hasUsablePasswordHash = (passwordHash: string | null): passwordHash is string => {
+  return typeof passwordHash === "string" && passwordHash.trim().length > 0;
+};
+
+const toLegacySessionAuthResult = ({
+  user,
+  pair
+}: {
+  user: SessionUserView;
+  pair: {
+    accessToken: string;
+    refreshToken: string;
+    accessExpiresIn: number;
+    refreshExpiresIn: number;
+  };
+}): SessionLoginResult => ({
+  accessToken: pair.accessToken,
+  refreshToken: pair.refreshToken,
+  expiresIn: pair.accessExpiresIn,
+  refreshExpiresIn: pair.refreshExpiresIn,
+  user: {
+    userId: user.userId,
+    role: user.role,
+    account: user.account,
+    displayName: user.name,
+    name: user.name,
+    teacherId: user.teacherId,
+    studentId: user.studentId,
+    studentNo: user.studentNo
+  }
+});
+
+const isSessionUserSame = (left: SessionUserView, right: SessionUserView): boolean => {
+  return left.userId === right.userId && left.role === right.role && left.account === right.account;
+};
+
+const isLegacyRefreshRecordActive = (record: SessionRefreshTokenRecord, now: Date): boolean => {
+  if (record.revokedAt) {
+    return false;
+  }
+
+  return record.expiresAt.getTime() > now.getTime();
+};
+
+const toLegacyRefreshRecord = ({
+  tokenHash,
+  user,
+  refreshExpiresAt,
+  now
+}: {
+  tokenHash: string;
+  user: SessionUserView;
+  refreshExpiresAt: Date;
+  now: Date;
+}): SessionRefreshTokenRecord => ({
+  tokenHash,
+  user,
+  createdAt: now,
+  expiresAt: refreshExpiresAt,
+  revokedAt: null
+});
+
+const createLegacyService = ({
+  accountRepo,
+  refreshTokenRepo,
+  passwordVerifier,
+  tokenManager
+}: LegacyCreateSessionAuthServiceInput): SessionAuthService => {
   return {
-    tokenHash: hashRefreshToken(refreshToken),
-    auth: verifiedRefreshToken.auth,
-    expiresAt: verifiedRefreshToken.expiresAt,
-    revokedAt: null,
-    createdAt: now
+    async login({ account, password }) {
+      const normalizedAccount = account.trim();
+      const accountRecord = await accountRepo.findByAccount(normalizedAccount);
+      const accountPasswordHash = accountRecord?.passwordHash ?? null;
+      const passwordHashForCompare = hasUsablePasswordHash(accountPasswordHash)
+        ? accountPasswordHash
+        : DUMMY_PASSWORD_HASH;
+      const passwordMatched = await passwordVerifier.compare(password, passwordHashForCompare);
+      const isFrozen = accountRecord?.status === "frozen";
+
+      if (!accountRecord || !hasUsablePasswordHash(accountRecord.passwordHash) || !passwordMatched || isFrozen) {
+        throw new SessionUnauthorizedError();
+      }
+
+      const user: SessionUserView = {
+        userId: accountRecord.userId,
+        role: accountRecord.role,
+        account: accountRecord.account,
+        name: accountRecord.name,
+        teacherId: accountRecord.teacherId,
+        studentId: accountRecord.studentId,
+        studentNo: accountRecord.studentNo
+      };
+
+      const tokenPair = tokenManager.createTokenPair(user);
+      const tokenHash = createHash("sha256").update(tokenPair.refreshToken).digest("hex");
+      const now = new Date();
+
+      await refreshTokenRepo.save(
+        toLegacyRefreshRecord({
+          tokenHash,
+          user,
+          refreshExpiresAt: tokenPair.refreshExpiresAt,
+          now
+        })
+      );
+
+      return toLegacySessionAuthResult({
+        user,
+        pair: tokenPair
+      });
+    },
+
+    async refresh(input) {
+      const refreshToken = resolveRefreshToken(input);
+      const verifiedToken = tokenManager.verifyRefreshToken(refreshToken);
+      if (!verifiedToken) {
+        throw new SessionUnauthorizedError();
+      }
+
+      const now = new Date();
+      const refreshTokenHash = createHash("sha256").update(refreshToken).digest("hex");
+      const existingRecord = await refreshTokenRepo.findByTokenHash(refreshTokenHash);
+
+      if (!existingRecord || !isLegacyRefreshRecordActive(existingRecord, now)) {
+        throw new SessionUnauthorizedError();
+      }
+
+      if (!isSessionUserSame(existingRecord.user, verifiedToken.user)) {
+        throw new SessionUnauthorizedError();
+      }
+
+      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
+
+      const tokenPair = tokenManager.createTokenPair(verifiedToken.user);
+      const nextTokenHash = createHash("sha256").update(tokenPair.refreshToken).digest("hex");
+
+      await refreshTokenRepo.save(
+        toLegacyRefreshRecord({
+          tokenHash: nextTokenHash,
+          user: verifiedToken.user,
+          refreshExpiresAt: tokenPair.refreshExpiresAt,
+          now
+        })
+      );
+
+      return toLegacySessionAuthResult({
+        user: verifiedToken.user,
+        pair: tokenPair
+      });
+    },
+
+    async logout(input) {
+      const refreshToken = resolveRefreshToken(input);
+      const now = new Date();
+      const refreshTokenHash = createHash("sha256").update(refreshToken).digest("hex");
+      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
+    },
+
+    async me(accessToken: string) {
+      const user = tokenManager.verifyAccessToken(accessToken);
+      if (!user) {
+        throw new SessionUnauthorizedError();
+      }
+
+      return toAuthPayloadFromSessionUser(user);
+    },
+
+    async getSessionUser({ accessToken }) {
+      const user = tokenManager.verifyAccessToken(accessToken);
+      if (!user) {
+        throw new SessionUnauthorizedError();
+      }
+      return user;
+    }
   };
 };
 
-export const createSessionAuthService = ({
+const createModernService = ({
   authenticator,
   authTokenSigner,
   authTokenVerifier,
   refreshTokenSigner,
   refreshTokenVerifier,
   refreshTokenRepo
-}: {
-  authenticator: SessionAuthenticator;
-  authTokenSigner: AuthTokenSigner;
-  authTokenVerifier: AuthTokenVerifier;
-  refreshTokenSigner: RefreshTokenSigner;
-  refreshTokenVerifier: RefreshTokenVerifier;
-  refreshTokenRepo: RefreshTokenRepository;
-}): SessionAuthService => {
+}: ModernCreateSessionAuthServiceInput): SessionAuthService => {
   return {
     async login({
       account,
@@ -136,7 +358,8 @@ export const createSessionAuthService = ({
       };
     },
 
-    async refresh(refreshToken: string): Promise<SessionLoginResult> {
+    async refresh(input): Promise<SessionLoginResult> {
+      const refreshToken = resolveRefreshToken(input);
       const verifiedRefreshToken = refreshTokenVerifier.verifyRefreshToken(refreshToken);
       if (!verifiedRefreshToken) {
         throw new SessionUnauthorizedError();
@@ -179,7 +402,8 @@ export const createSessionAuthService = ({
       };
     },
 
-    async logout(refreshToken: string): Promise<void> {
+    async logout(input): Promise<void> {
+      const refreshToken = resolveRefreshToken(input);
       await refreshTokenRepo.revokeByTokenHash(hashRefreshToken(refreshToken), new Date());
     },
 
@@ -189,6 +413,24 @@ export const createSessionAuthService = ({
         throw new SessionUnauthorizedError();
       }
       return auth;
+    },
+
+    async getSessionUser({ accessToken }) {
+      const auth = authTokenVerifier.verifyAuthToken(accessToken);
+      if (!auth) {
+        throw new SessionUnauthorizedError();
+      }
+      return toSessionUserFromAuthPayload(auth);
     }
   };
+};
+
+export const createSessionAuthService = (
+  input: LegacyCreateSessionAuthServiceInput | ModernCreateSessionAuthServiceInput
+): SessionAuthService => {
+  if ("accountRepo" in input && "tokenManager" in input) {
+    return createLegacyService(input);
+  }
+
+  return createModernService(input);
 };

--- a/src/modules/auth/session-service.ts
+++ b/src/modules/auth/session-service.ts
@@ -1,183 +1,194 @@
-import { createHash } from "node:crypto";
+import type { AuthTokenPayload, AuthTokenSigner, AuthTokenVerifier } from "./session-token.js";
 import type {
-  CreateSessionAuthServiceInput,
-  SessionAuthResult,
-  SessionRefreshTokenRecord,
-  SessionUserView
-} from "./session.js";
-import { SessionAuthUnauthorizedError } from "./session.js";
+  RefreshTokenSigner,
+  RefreshTokenVerifier,
+  VerifiedRefreshTokenPayload
+} from "./refresh-token.js";
+import { hashRefreshToken } from "./refresh-token.js";
 
-const DUMMY_PASSWORD_HASH = "$2b$10$ykqJ8CfeprKl2UpQm9a7ZOv9wZWyG2J.AoPTB5oTvbGdZyc/Ljcsm";
-
-const hasUsablePasswordHash = (passwordHash: string | null): passwordHash is string => {
-  return typeof passwordHash === "string" && passwordHash.trim().length > 0;
-};
-
-const hashRefreshToken = (token: string): string => {
-  return createHash("sha256").update(token).digest("hex");
-};
-
-const toSessionUserView = (account: {
-  userId: string;
-  role: "admin" | "teacher" | "student";
-  account: string;
-  name: string;
-  teacherId?: string;
-  studentId?: number;
-  studentNo?: string;
-}): SessionUserView => {
-  return {
-    userId: account.userId,
-    role: account.role,
-    account: account.account,
-    name: account.name,
-    teacherId: account.teacherId,
-    studentId: account.studentId,
-    studentNo: account.studentNo
+export interface SessionLoginResult {
+  accessToken: string;
+  expiresIn: number;
+  refreshToken: string;
+  refreshExpiresIn: number;
+  user: {
+    userId: string;
+    role: AuthTokenPayload["role"];
+    displayName: string;
+    account: string;
   };
-};
+}
 
-const toSessionAuthResult = ({
-  user,
-  pair
-}: {
-  user: SessionUserView;
-  pair: {
-    accessToken: string;
-    refreshToken: string;
-    accessExpiresIn: number;
-    refreshExpiresIn: number;
-  };
-}): SessionAuthResult => {
-  return {
-    accessToken: pair.accessToken,
-    refreshToken: pair.refreshToken,
-    expiresIn: pair.accessExpiresIn,
-    refreshExpiresIn: pair.refreshExpiresIn,
-    user
-  };
-};
+export interface SessionAuthService {
+  login(input: { account: string; password: string }): Promise<SessionLoginResult>;
+  refresh(refreshToken: string): Promise<SessionLoginResult>;
+  logout(refreshToken: string): Promise<void>;
+  me(accessToken: string): Promise<AuthTokenPayload>;
+}
 
-const isSessionUserSame = (left: SessionUserView, right: SessionUserView): boolean => {
-  return left.userId === right.userId && left.role === right.role && left.account === right.account;
-};
+export interface SessionAuthenticator {
+  loginByAccount(account: string, password: string): Promise<AuthTokenPayload>;
+}
 
-const isRefreshRecordActive = (record: SessionRefreshTokenRecord, now: Date): boolean => {
+export interface RefreshTokenRecord {
+  tokenHash: string;
+  auth: AuthTokenPayload;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+}
+
+export interface RefreshTokenRepository {
+  save(record: RefreshTokenRecord): Promise<void>;
+  findByTokenHash(tokenHash: string): Promise<RefreshTokenRecord | null>;
+  revokeByTokenHash(tokenHash: string, revokedAt: Date): Promise<void>;
+}
+
+export class SessionUnauthorizedError extends Error {
+  constructor() {
+    super("unauthorized");
+    this.name = "SessionUnauthorizedError";
+  }
+}
+
+const toPublicUser = (auth: AuthTokenPayload) => ({
+  userId: auth.sub,
+  role: auth.role,
+  displayName: auth.displayName ?? auth.account,
+  account: auth.account
+});
+
+const isRefreshTokenRecordActive = (record: RefreshTokenRecord, now: Date): boolean => {
   if (record.revokedAt) {
     return false;
   }
-
   return record.expiresAt.getTime() > now.getTime();
 };
 
+const isAuthSubjectSame = (left: AuthTokenPayload, right: AuthTokenPayload): boolean => {
+  return left.sub === right.sub && left.role === right.role && left.account === right.account;
+};
+
 const buildRefreshRecord = ({
-  tokenHash,
-  user,
-  refreshExpiresAt,
+  refreshToken,
+  verifiedRefreshToken,
   now
 }: {
-  tokenHash: string;
-  user: SessionUserView;
-  refreshExpiresAt: Date;
+  refreshToken: string;
+  verifiedRefreshToken: VerifiedRefreshTokenPayload;
   now: Date;
-}): SessionRefreshTokenRecord => {
+}): RefreshTokenRecord => {
   return {
-    tokenHash,
-    user,
-    createdAt: now,
-    expiresAt: refreshExpiresAt,
-    revokedAt: null
+    tokenHash: hashRefreshToken(refreshToken),
+    auth: verifiedRefreshToken.auth,
+    expiresAt: verifiedRefreshToken.expiresAt,
+    revokedAt: null,
+    createdAt: now
   };
 };
 
 export const createSessionAuthService = ({
-  accountRepo,
-  refreshTokenRepo,
-  passwordVerifier,
-  tokenManager
-}: CreateSessionAuthServiceInput) => {
+  authenticator,
+  authTokenSigner,
+  authTokenVerifier,
+  refreshTokenSigner,
+  refreshTokenVerifier,
+  refreshTokenRepo
+}: {
+  authenticator: SessionAuthenticator;
+  authTokenSigner: AuthTokenSigner;
+  authTokenVerifier: AuthTokenVerifier;
+  refreshTokenSigner: RefreshTokenSigner;
+  refreshTokenVerifier: RefreshTokenVerifier;
+  refreshTokenRepo: RefreshTokenRepository;
+}): SessionAuthService => {
   return {
-    async login({ account, password }) {
-      const normalizedAccount = account.trim();
-      const accountRecord = await accountRepo.findByAccount(normalizedAccount);
-      const passwordHashForCompare = hasUsablePasswordHash(accountRecord?.passwordHash ?? null)
-        ? accountRecord!.passwordHash
-        : DUMMY_PASSWORD_HASH;
-      const passwordMatched = await passwordVerifier.compare(password, passwordHashForCompare);
-      const isFrozen = accountRecord?.status === "frozen";
+    async login({
+      account,
+      password
+    }: {
+      account: string;
+      password: string;
+    }): Promise<SessionLoginResult> {
+      const auth = await authenticator.loginByAccount(account, password);
+      const accessToken = authTokenSigner.signAuthToken(auth);
+      const refreshToken = refreshTokenSigner.signRefreshToken(auth);
+      const verifiedRefreshToken = refreshTokenVerifier.verifyRefreshToken(refreshToken);
 
-      if (!accountRecord || !hasUsablePasswordHash(accountRecord.passwordHash) || !passwordMatched || isFrozen) {
-        throw new SessionAuthUnauthorizedError();
+      if (!verifiedRefreshToken) {
+        throw new SessionUnauthorizedError();
       }
-
-      const user = toSessionUserView(accountRecord);
-      const tokenPair = tokenManager.createTokenPair(user);
-      const tokenHash = hashRefreshToken(tokenPair.refreshToken);
-      const now = new Date();
 
       await refreshTokenRepo.save(
         buildRefreshRecord({
-          tokenHash,
-          user,
-          refreshExpiresAt: tokenPair.refreshExpiresAt,
+          refreshToken,
+          verifiedRefreshToken,
+          now: new Date()
+        })
+      );
+
+      return {
+        accessToken,
+        expiresIn: authTokenSigner.expiresIn,
+        refreshToken,
+        refreshExpiresIn: refreshTokenSigner.expiresIn,
+        user: toPublicUser(auth)
+      };
+    },
+
+    async refresh(refreshToken: string): Promise<SessionLoginResult> {
+      const verifiedRefreshToken = refreshTokenVerifier.verifyRefreshToken(refreshToken);
+      if (!verifiedRefreshToken) {
+        throw new SessionUnauthorizedError();
+      }
+
+      const now = new Date();
+      const tokenHash = hashRefreshToken(refreshToken);
+      const existing = await refreshTokenRepo.findByTokenHash(tokenHash);
+      if (!existing || !isRefreshTokenRecordActive(existing, now)) {
+        throw new SessionUnauthorizedError();
+      }
+
+      if (!isAuthSubjectSame(existing.auth, verifiedRefreshToken.auth)) {
+        throw new SessionUnauthorizedError();
+      }
+
+      await refreshTokenRepo.revokeByTokenHash(tokenHash, now);
+
+      const nextAccessToken = authTokenSigner.signAuthToken(verifiedRefreshToken.auth);
+      const nextRefreshToken = refreshTokenSigner.signRefreshToken(verifiedRefreshToken.auth);
+      const verifiedNextRefreshToken = refreshTokenVerifier.verifyRefreshToken(nextRefreshToken);
+      if (!verifiedNextRefreshToken) {
+        throw new SessionUnauthorizedError();
+      }
+
+      await refreshTokenRepo.save(
+        buildRefreshRecord({
+          refreshToken: nextRefreshToken,
+          verifiedRefreshToken: verifiedNextRefreshToken,
           now
         })
       );
 
-      return toSessionAuthResult({
-        user,
-        pair: tokenPair
-      });
+      return {
+        accessToken: nextAccessToken,
+        expiresIn: authTokenSigner.expiresIn,
+        refreshToken: nextRefreshToken,
+        refreshExpiresIn: refreshTokenSigner.expiresIn,
+        user: toPublicUser(verifiedRefreshToken.auth)
+      };
     },
-    async refresh({ refreshToken }) {
-      const verifiedToken = tokenManager.verifyRefreshToken(refreshToken);
-      if (!verifiedToken) {
-        throw new SessionAuthUnauthorizedError();
-      }
 
-      const now = new Date();
-      const refreshTokenHash = hashRefreshToken(refreshToken);
-      const existingRecord = await refreshTokenRepo.findByTokenHash(refreshTokenHash);
-
-      if (!existingRecord || !isRefreshRecordActive(existingRecord, now)) {
-        throw new SessionAuthUnauthorizedError();
-      }
-
-      if (!isSessionUserSame(existingRecord.user, verifiedToken.user)) {
-        throw new SessionAuthUnauthorizedError();
-      }
-
-      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
-
-      const tokenPair = tokenManager.createTokenPair(verifiedToken.user);
-      const nextTokenHash = hashRefreshToken(tokenPair.refreshToken);
-
-      await refreshTokenRepo.save(
-        buildRefreshRecord({
-          tokenHash: nextTokenHash,
-          user: verifiedToken.user,
-          refreshExpiresAt: tokenPair.refreshExpiresAt,
-          now
-        })
-      );
-
-      return toSessionAuthResult({
-        user: verifiedToken.user,
-        pair: tokenPair
-      });
+    async logout(refreshToken: string): Promise<void> {
+      await refreshTokenRepo.revokeByTokenHash(hashRefreshToken(refreshToken), new Date());
     },
-    async logout({ refreshToken }) {
-      const now = new Date();
-      const refreshTokenHash = hashRefreshToken(refreshToken);
-      await refreshTokenRepo.revokeByTokenHash(refreshTokenHash, now);
-    },
-    async getSessionUser({ accessToken }) {
-      const user = tokenManager.verifyAccessToken(accessToken);
-      if (!user) {
-        throw new SessionAuthUnauthorizedError();
-      }
 
-      return user;
+    async me(accessToken: string): Promise<AuthTokenPayload> {
+      const auth = authTokenVerifier.verifyAuthToken(accessToken);
+      if (!auth) {
+        throw new SessionUnauthorizedError();
+      }
+      return auth;
     }
   };
 };

--- a/src/modules/auth/session-token.ts
+++ b/src/modules/auth/session-token.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
+import type {
+  SessionRole,
+  SessionTokenManager,
+  SessionTokenPair,
+  SessionUserView,
+  VerifiedRefreshToken
+} from "./session.js";
+
+const require = createRequire(import.meta.url);
+const jwt = require("jsonwebtoken") as {
+  sign(payload: Record<string, unknown>, secret: string, options: { expiresIn: number }): string;
+  verify(token: string, secret: string): string | Record<string, unknown>;
+};
+
+const DEFAULT_ACCESS_EXPIRES_IN_SECONDS = 15 * 60;
+const DEFAULT_REFRESH_EXPIRES_IN_SECONDS = 30 * 24 * 60 * 60;
+const ACCESS_TOKEN_TYPE = "access";
+const REFRESH_TOKEN_TYPE = "refresh";
+
+interface CreateJwtSessionTokenManagerInput {
+  secret: string;
+  accessExpiresInSeconds?: number;
+  refreshExpiresInSeconds?: number;
+}
+
+interface SessionJwtPayloadShape {
+  sub: string;
+  role: SessionRole;
+  account: string;
+  name: string;
+  tokenType: "access" | "refresh";
+  studentId?: number;
+  studentNo?: string;
+  teacherId?: string;
+  exp?: number;
+}
+
+const isSessionRole = (value: unknown): value is SessionRole => {
+  return value === "admin" || value === "teacher" || value === "student";
+};
+
+const isValidSessionUser = (value: SessionUserView): boolean => {
+  if (!value.userId || !value.account || !value.name) {
+    return false;
+  }
+
+  if (!isSessionRole(value.role)) {
+    return false;
+  }
+
+  return true;
+};
+
+const toSessionPayload = (
+  payload: string | Record<string, unknown>
+): SessionJwtPayloadShape | null => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const sub = payload.sub;
+  const role = payload.role;
+  const account = payload.account;
+  const name = payload.name;
+  const tokenType = payload.tokenType;
+  const exp = payload.exp;
+
+  if (
+    typeof sub !== "string" ||
+    !isSessionRole(role) ||
+    typeof account !== "string" ||
+    typeof name !== "string" ||
+    (tokenType !== ACCESS_TOKEN_TYPE && tokenType !== REFRESH_TOKEN_TYPE)
+  ) {
+    return null;
+  }
+
+  const basePayload: SessionJwtPayloadShape = {
+    sub,
+    role,
+    account,
+    name,
+    tokenType
+  };
+
+  if (typeof payload.studentNo === "string") {
+    basePayload.studentNo = payload.studentNo;
+  }
+  if (typeof payload.teacherId === "string") {
+    basePayload.teacherId = payload.teacherId;
+  }
+  if (typeof payload.studentId === "number" && Number.isInteger(payload.studentId)) {
+    basePayload.studentId = payload.studentId;
+  }
+  if (typeof exp === "number" && Number.isInteger(exp)) {
+    basePayload.exp = exp;
+  }
+
+  return basePayload;
+};
+
+const toUserView = (payload: SessionJwtPayloadShape): SessionUserView => {
+  return {
+    userId: payload.sub,
+    role: payload.role,
+    account: payload.account,
+    name: payload.name,
+    studentNo: payload.studentNo,
+    teacherId: payload.teacherId,
+    studentId: payload.studentId
+  };
+};
+
+const toRefreshExpiresAt = (payload: SessionJwtPayloadShape): Date | null => {
+  if (!payload.exp) {
+    return null;
+  }
+
+  return new Date(payload.exp * 1000);
+};
+
+const signToken = ({
+  secret,
+  expiresInSeconds,
+  tokenType,
+  user
+}: {
+  secret: string;
+  expiresInSeconds: number;
+  tokenType: "access" | "refresh";
+  user: SessionUserView;
+}): string => {
+  const payload: Record<string, unknown> = {
+    sub: user.userId,
+    role: user.role,
+    account: user.account,
+    name: user.name,
+    tokenType
+  };
+
+  if (user.studentId) {
+    payload.studentId = user.studentId;
+  }
+  if (user.studentNo) {
+    payload.studentNo = user.studentNo;
+  }
+  if (user.teacherId) {
+    payload.teacherId = user.teacherId;
+  }
+  if (tokenType === REFRESH_TOKEN_TYPE) {
+    payload.jti = randomUUID();
+  }
+
+  return jwt.sign(payload, secret, { expiresIn: expiresInSeconds });
+};
+
+const verifyTokenPayload = (
+  secret: string,
+  token: string,
+  expectedTokenType: "access" | "refresh"
+): SessionJwtPayloadShape | null => {
+  try {
+    const payload = jwt.verify(token, secret);
+    const decoded = toSessionPayload(payload);
+    if (!decoded || decoded.tokenType !== expectedTokenType) {
+      return null;
+    }
+
+    return decoded;
+  } catch {
+    return null;
+  }
+};
+
+const toTokenPair = ({
+  user,
+  secret,
+  accessExpiresIn,
+  refreshExpiresIn
+}: {
+  user: SessionUserView;
+  secret: string;
+  accessExpiresIn: number;
+  refreshExpiresIn: number;
+}): SessionTokenPair => {
+  const accessToken = signToken({
+    secret,
+    expiresInSeconds: accessExpiresIn,
+    tokenType: ACCESS_TOKEN_TYPE,
+    user
+  });
+  const refreshToken = signToken({
+    secret,
+    expiresInSeconds: refreshExpiresIn,
+    tokenType: REFRESH_TOKEN_TYPE,
+    user
+  });
+
+  return {
+    accessToken,
+    refreshToken,
+    accessExpiresIn,
+    refreshExpiresIn,
+    refreshExpiresAt: new Date(Date.now() + refreshExpiresIn * 1000)
+  };
+};
+
+const toVerifiedRefreshToken = (payload: SessionJwtPayloadShape): VerifiedRefreshToken | null => {
+  const expiresAt = toRefreshExpiresAt(payload);
+  if (!expiresAt) {
+    return null;
+  }
+
+  return {
+    user: toUserView(payload),
+    expiresAt
+  };
+};
+
+export const createJwtSessionTokenManager = ({
+  secret,
+  accessExpiresInSeconds = DEFAULT_ACCESS_EXPIRES_IN_SECONDS,
+  refreshExpiresInSeconds = DEFAULT_REFRESH_EXPIRES_IN_SECONDS
+}: CreateJwtSessionTokenManagerInput): SessionTokenManager => {
+  return {
+    createTokenPair(user) {
+      if (!isValidSessionUser(user)) {
+        throw new Error("invalid session user");
+      }
+
+      return toTokenPair({
+        user,
+        secret,
+        accessExpiresIn: accessExpiresInSeconds,
+        refreshExpiresIn: refreshExpiresInSeconds
+      });
+    },
+    verifyAccessToken(token) {
+      const payload = verifyTokenPayload(secret, token, ACCESS_TOKEN_TYPE);
+      if (!payload) {
+        return null;
+      }
+
+      return toUserView(payload);
+    },
+    verifyRefreshToken(token) {
+      const payload = verifyTokenPayload(secret, token, REFRESH_TOKEN_TYPE);
+      if (!payload) {
+        return null;
+      }
+
+      return toVerifiedRefreshToken(payload);
+    }
+  };
+};

--- a/src/modules/auth/session-token.ts
+++ b/src/modules/auth/session-token.ts
@@ -1,12 +1,4 @@
-import { randomUUID } from "node:crypto";
 import { createRequire } from "node:module";
-import type {
-  SessionRole,
-  SessionTokenManager,
-  SessionTokenPair,
-  SessionUserView,
-  VerifiedRefreshToken
-} from "./session.js";
 
 const require = createRequire(import.meta.url);
 const jwt = require("jsonwebtoken") as {
@@ -14,48 +6,52 @@ const jwt = require("jsonwebtoken") as {
   verify(token: string, secret: string): string | Record<string, unknown>;
 };
 
-const DEFAULT_ACCESS_EXPIRES_IN_SECONDS = 15 * 60;
-const DEFAULT_REFRESH_EXPIRES_IN_SECONDS = 30 * 24 * 60 * 60;
-const ACCESS_TOKEN_TYPE = "access";
-const REFRESH_TOKEN_TYPE = "refresh";
+const SECONDS_PER_DAY = 24 * 60 * 60;
 
-interface CreateJwtSessionTokenManagerInput {
-  secret: string;
-  accessExpiresInSeconds?: number;
-  refreshExpiresInSeconds?: number;
-}
+export type AuthRole = "student" | "teacher" | "admin";
 
-interface SessionJwtPayloadShape {
+export interface AuthTokenPayload {
   sub: string;
-  role: SessionRole;
+  role: AuthRole;
   account: string;
-  name: string;
-  tokenType: "access" | "refresh";
+  displayName?: string;
   studentId?: number;
   studentNo?: string;
   teacherId?: string;
-  exp?: number;
+  schoolId?: number;
+  collegeId?: number;
+  majorId?: number;
+  classId?: number;
+  mustChangePassword?: boolean;
 }
 
-const isSessionRole = (value: unknown): value is SessionRole => {
-  return value === "admin" || value === "teacher" || value === "student";
+export interface AuthTokenSigner {
+  expiresIn: number;
+  signAuthToken(payload: AuthTokenPayload): string;
+}
+
+export interface CreateAuthTokenSignerInput {
+  secret: string;
+  expiresInDays: number;
+}
+
+export interface AuthTokenVerifier {
+  verifyAuthToken(token: string): AuthTokenPayload | null;
+}
+
+export interface CreateAuthTokenVerifierInput {
+  secret: string;
+}
+
+const isPositiveInteger = (value: unknown): value is number => {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
 };
 
-const isValidSessionUser = (value: SessionUserView): boolean => {
-  if (!value.userId || !value.account || !value.name) {
-    return false;
-  }
-
-  if (!isSessionRole(value.role)) {
-    return false;
-  }
-
-  return true;
+const normalizeOptionalInteger = (value: unknown): number | undefined => {
+  return isPositiveInteger(value) ? value : undefined;
 };
 
-const toSessionPayload = (
-  payload: string | Record<string, unknown>
-): SessionJwtPayloadShape | null => {
+const toVerifiedPayload = (payload: string | Record<string, unknown>): AuthTokenPayload | null => {
   if (!payload || typeof payload !== "object") {
     return null;
   }
@@ -63,195 +59,62 @@ const toSessionPayload = (
   const sub = payload.sub;
   const role = payload.role;
   const account = payload.account;
-  const name = payload.name;
-  const tokenType = payload.tokenType;
-  const exp = payload.exp;
 
-  if (
-    typeof sub !== "string" ||
-    !isSessionRole(role) ||
-    typeof account !== "string" ||
-    typeof name !== "string" ||
-    (tokenType !== ACCESS_TOKEN_TYPE && tokenType !== REFRESH_TOKEN_TYPE)
-  ) {
+  if (typeof sub !== "string" || (role !== "student" && role !== "teacher" && role !== "admin") || typeof account !== "string") {
     return null;
   }
 
-  const basePayload: SessionJwtPayloadShape = {
+  const studentId = normalizeOptionalInteger(payload.studentId);
+  const displayName = typeof payload.displayName === "string" ? payload.displayName : undefined;
+  const schoolId = normalizeOptionalInteger(payload.schoolId);
+  const collegeId = normalizeOptionalInteger(payload.collegeId);
+  const majorId = normalizeOptionalInteger(payload.majorId);
+  const classId = normalizeOptionalInteger(payload.classId);
+  const studentNo = typeof payload.studentNo === "string" ? payload.studentNo : undefined;
+  const teacherId = typeof payload.teacherId === "string" ? payload.teacherId : undefined;
+  const mustChangePassword = typeof payload.mustChangePassword === "boolean" ? payload.mustChangePassword : undefined;
+
+  return {
     sub,
     role,
     account,
-    name,
-    tokenType
-  };
-
-  if (typeof payload.studentNo === "string") {
-    basePayload.studentNo = payload.studentNo;
-  }
-  if (typeof payload.teacherId === "string") {
-    basePayload.teacherId = payload.teacherId;
-  }
-  if (typeof payload.studentId === "number" && Number.isInteger(payload.studentId)) {
-    basePayload.studentId = payload.studentId;
-  }
-  if (typeof exp === "number" && Number.isInteger(exp)) {
-    basePayload.exp = exp;
-  }
-
-  return basePayload;
-};
-
-const toUserView = (payload: SessionJwtPayloadShape): SessionUserView => {
-  return {
-    userId: payload.sub,
-    role: payload.role,
-    account: payload.account,
-    name: payload.name,
-    studentNo: payload.studentNo,
-    teacherId: payload.teacherId,
-    studentId: payload.studentId
+    displayName,
+    studentId,
+    studentNo,
+    teacherId,
+    schoolId,
+    collegeId,
+    majorId,
+    classId,
+    mustChangePassword
   };
 };
 
-const toRefreshExpiresAt = (payload: SessionJwtPayloadShape): Date | null => {
-  if (!payload.exp) {
-    return null;
-  }
-
-  return new Date(payload.exp * 1000);
-};
-
-const signToken = ({
+export const createJwtAuthTokenSigner = ({
   secret,
-  expiresInSeconds,
-  tokenType,
-  user
-}: {
-  secret: string;
-  expiresInSeconds: number;
-  tokenType: "access" | "refresh";
-  user: SessionUserView;
-}): string => {
-  const payload: Record<string, unknown> = {
-    sub: user.userId,
-    role: user.role,
-    account: user.account,
-    name: user.name,
-    tokenType
-  };
+  expiresInDays
+}: CreateAuthTokenSignerInput): AuthTokenSigner => {
+  const expiresIn = expiresInDays * SECONDS_PER_DAY;
 
-  if (user.studentId) {
-    payload.studentId = user.studentId;
-  }
-  if (user.studentNo) {
-    payload.studentNo = user.studentNo;
-  }
-  if (user.teacherId) {
-    payload.teacherId = user.teacherId;
-  }
-  if (tokenType === REFRESH_TOKEN_TYPE) {
-    payload.jti = randomUUID();
-  }
-
-  return jwt.sign(payload, secret, { expiresIn: expiresInSeconds });
-};
-
-const verifyTokenPayload = (
-  secret: string,
-  token: string,
-  expectedTokenType: "access" | "refresh"
-): SessionJwtPayloadShape | null => {
-  try {
-    const payload = jwt.verify(token, secret);
-    const decoded = toSessionPayload(payload);
-    if (!decoded || decoded.tokenType !== expectedTokenType) {
-      return null;
+  return {
+    expiresIn,
+    signAuthToken(payload) {
+      return jwt.sign(payload as unknown as Record<string, unknown>, secret, { expiresIn });
     }
-
-    return decoded;
-  } catch {
-    return null;
-  }
-};
-
-const toTokenPair = ({
-  user,
-  secret,
-  accessExpiresIn,
-  refreshExpiresIn
-}: {
-  user: SessionUserView;
-  secret: string;
-  accessExpiresIn: number;
-  refreshExpiresIn: number;
-}): SessionTokenPair => {
-  const accessToken = signToken({
-    secret,
-    expiresInSeconds: accessExpiresIn,
-    tokenType: ACCESS_TOKEN_TYPE,
-    user
-  });
-  const refreshToken = signToken({
-    secret,
-    expiresInSeconds: refreshExpiresIn,
-    tokenType: REFRESH_TOKEN_TYPE,
-    user
-  });
-
-  return {
-    accessToken,
-    refreshToken,
-    accessExpiresIn,
-    refreshExpiresIn,
-    refreshExpiresAt: new Date(Date.now() + refreshExpiresIn * 1000)
   };
 };
 
-const toVerifiedRefreshToken = (payload: SessionJwtPayloadShape): VerifiedRefreshToken | null => {
-  const expiresAt = toRefreshExpiresAt(payload);
-  if (!expiresAt) {
-    return null;
-  }
-
+export const createJwtAuthTokenVerifier = ({
+  secret
+}: CreateAuthTokenVerifierInput): AuthTokenVerifier => {
   return {
-    user: toUserView(payload),
-    expiresAt
-  };
-};
-
-export const createJwtSessionTokenManager = ({
-  secret,
-  accessExpiresInSeconds = DEFAULT_ACCESS_EXPIRES_IN_SECONDS,
-  refreshExpiresInSeconds = DEFAULT_REFRESH_EXPIRES_IN_SECONDS
-}: CreateJwtSessionTokenManagerInput): SessionTokenManager => {
-  return {
-    createTokenPair(user) {
-      if (!isValidSessionUser(user)) {
-        throw new Error("invalid session user");
-      }
-
-      return toTokenPair({
-        user,
-        secret,
-        accessExpiresIn: accessExpiresInSeconds,
-        refreshExpiresIn: refreshExpiresInSeconds
-      });
-    },
-    verifyAccessToken(token) {
-      const payload = verifyTokenPayload(secret, token, ACCESS_TOKEN_TYPE);
-      if (!payload) {
+    verifyAuthToken(token) {
+      try {
+        const decoded = jwt.verify(token, secret);
+        return toVerifiedPayload(decoded);
+      } catch {
         return null;
       }
-
-      return toUserView(payload);
-    },
-    verifyRefreshToken(token) {
-      const payload = verifyTokenPayload(secret, token, REFRESH_TOKEN_TYPE);
-      if (!payload) {
-        return null;
-      }
-
-      return toVerifiedRefreshToken(payload);
     }
   };
 };

--- a/src/modules/auth/session-token.ts
+++ b/src/modules/auth/session-token.ts
@@ -1,4 +1,12 @@
 import { createRequire } from "node:module";
+import { randomUUID } from "node:crypto";
+import type {
+  SessionRole,
+  SessionTokenManager,
+  SessionTokenPair,
+  SessionUserView,
+  VerifiedRefreshToken
+} from "./session.js";
 
 const require = createRequire(import.meta.url);
 const jwt = require("jsonwebtoken") as {
@@ -7,6 +15,10 @@ const jwt = require("jsonwebtoken") as {
 };
 
 const SECONDS_PER_DAY = 24 * 60 * 60;
+const DEFAULT_ACCESS_EXPIRES_IN_SECONDS = 15 * 60;
+const DEFAULT_REFRESH_EXPIRES_IN_SECONDS = 30 * 24 * 60 * 60;
+const ACCESS_TOKEN_TYPE = "access";
+const REFRESH_TOKEN_TYPE = "refresh";
 
 export type AuthRole = "student" | "teacher" | "admin";
 
@@ -41,6 +53,18 @@ export interface AuthTokenVerifier {
 
 export interface CreateAuthTokenVerifierInput {
   secret: string;
+}
+
+interface SessionJwtPayloadShape {
+  sub: string;
+  role: SessionRole;
+  account: string;
+  name: string;
+  tokenType: "access" | "refresh";
+  studentId?: number;
+  studentNo?: string;
+  teacherId?: string;
+  exp?: number;
 }
 
 const isPositiveInteger = (value: unknown): value is number => {
@@ -115,6 +139,176 @@ export const createJwtAuthTokenVerifier = ({
       } catch {
         return null;
       }
+    }
+  };
+};
+
+const isSessionRole = (value: unknown): value is SessionRole => {
+  return value === "admin" || value === "teacher" || value === "student";
+};
+
+const toSessionPayload = (
+  payload: string | Record<string, unknown>
+): SessionJwtPayloadShape | null => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const sub = payload.sub;
+  const role = payload.role;
+  const account = payload.account;
+  const name = payload.name;
+  const tokenType = payload.tokenType;
+  const exp = payload.exp;
+
+  if (
+    typeof sub !== "string" ||
+    !isSessionRole(role) ||
+    typeof account !== "string" ||
+    typeof name !== "string" ||
+    (tokenType !== ACCESS_TOKEN_TYPE && tokenType !== REFRESH_TOKEN_TYPE)
+  ) {
+    return null;
+  }
+
+  const basePayload: SessionJwtPayloadShape = {
+    sub,
+    role,
+    account,
+    name,
+    tokenType
+  };
+
+  if (typeof payload.studentNo === "string") {
+    basePayload.studentNo = payload.studentNo;
+  }
+  if (typeof payload.teacherId === "string") {
+    basePayload.teacherId = payload.teacherId;
+  }
+  if (typeof payload.studentId === "number" && Number.isInteger(payload.studentId)) {
+    basePayload.studentId = payload.studentId;
+  }
+  if (typeof exp === "number" && Number.isInteger(exp)) {
+    basePayload.exp = exp;
+  }
+
+  return basePayload;
+};
+
+const toSessionUserView = (payload: SessionJwtPayloadShape): SessionUserView => {
+  return {
+    userId: payload.sub,
+    role: payload.role,
+    account: payload.account,
+    name: payload.name,
+    studentNo: payload.studentNo,
+    teacherId: payload.teacherId,
+    studentId: payload.studentId
+  };
+};
+
+const signSessionToken = ({
+  secret,
+  expiresInSeconds,
+  tokenType,
+  user
+}: {
+  secret: string;
+  expiresInSeconds: number;
+  tokenType: "access" | "refresh";
+  user: SessionUserView;
+}): string => {
+  const payload: Record<string, unknown> = {
+    sub: user.userId,
+    role: user.role,
+    account: user.account,
+    name: user.name,
+    tokenType
+  };
+
+  if (user.studentId) {
+    payload.studentId = user.studentId;
+  }
+  if (user.studentNo) {
+    payload.studentNo = user.studentNo;
+  }
+  if (user.teacherId) {
+    payload.teacherId = user.teacherId;
+  }
+  if (tokenType === REFRESH_TOKEN_TYPE) {
+    payload.jti = randomUUID();
+  }
+
+  return jwt.sign(payload, secret, { expiresIn: expiresInSeconds });
+};
+
+const verifySessionToken = (
+  secret: string,
+  token: string,
+  expectedTokenType: "access" | "refresh"
+): SessionJwtPayloadShape | null => {
+  try {
+    const payload = jwt.verify(token, secret);
+    const decoded = toSessionPayload(payload);
+    if (!decoded || decoded.tokenType !== expectedTokenType) {
+      return null;
+    }
+
+    return decoded;
+  } catch {
+    return null;
+  }
+};
+
+export const createJwtSessionTokenManager = ({
+  secret,
+  accessExpiresInSeconds = DEFAULT_ACCESS_EXPIRES_IN_SECONDS,
+  refreshExpiresInSeconds = DEFAULT_REFRESH_EXPIRES_IN_SECONDS
+}: {
+  secret: string;
+  accessExpiresInSeconds?: number;
+  refreshExpiresInSeconds?: number;
+}): SessionTokenManager => {
+  return {
+    createTokenPair(user): SessionTokenPair {
+      const accessToken = signSessionToken({
+        secret,
+        expiresInSeconds: accessExpiresInSeconds,
+        tokenType: ACCESS_TOKEN_TYPE,
+        user
+      });
+      const refreshToken = signSessionToken({
+        secret,
+        expiresInSeconds: refreshExpiresInSeconds,
+        tokenType: REFRESH_TOKEN_TYPE,
+        user
+      });
+
+      return {
+        accessToken,
+        refreshToken,
+        accessExpiresIn: accessExpiresInSeconds,
+        refreshExpiresIn: refreshExpiresInSeconds,
+        refreshExpiresAt: new Date(Date.now() + refreshExpiresInSeconds * 1000)
+      };
+    },
+    verifyAccessToken(token) {
+      const payload = verifySessionToken(secret, token, ACCESS_TOKEN_TYPE);
+      if (!payload) {
+        return null;
+      }
+      return toSessionUserView(payload);
+    },
+    verifyRefreshToken(token): VerifiedRefreshToken | null {
+      const payload = verifySessionToken(secret, token, REFRESH_TOKEN_TYPE);
+      if (!payload || !payload.exp) {
+        return null;
+      }
+
+      return {
+        user: toSessionUserView(payload),
+        expiresAt: new Date(payload.exp * 1000)
+      };
     }
   };
 };

--- a/src/modules/auth/session.ts
+++ b/src/modules/auth/session.ts
@@ -1,0 +1,101 @@
+import type { PasswordVerifier } from "./password.js";
+
+export type SessionRole = "admin" | "teacher" | "student";
+
+export interface SessionUserView {
+  userId: string;
+  role: SessionRole;
+  account: string;
+  name: string;
+  teacherId?: string;
+  studentId?: number;
+  studentNo?: string;
+}
+
+export interface SessionAccountRecord extends SessionUserView {
+  passwordHash: string | null;
+  status?: "active" | "frozen";
+}
+
+export interface SessionAccountRepository {
+  findByAccount(account: string): Promise<SessionAccountRecord | null>;
+}
+
+export interface SessionRefreshTokenRecord {
+  tokenHash: string;
+  user: SessionUserView;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  createdAt: Date;
+}
+
+export interface SessionRefreshTokenRepository {
+  save(record: SessionRefreshTokenRecord): Promise<void>;
+  findByTokenHash(tokenHash: string): Promise<SessionRefreshTokenRecord | null>;
+  revokeByTokenHash(tokenHash: string, revokedAt: Date): Promise<void>;
+}
+
+export interface SessionTokenPair {
+  accessToken: string;
+  refreshToken: string;
+  accessExpiresIn: number;
+  refreshExpiresIn: number;
+  refreshExpiresAt: Date;
+}
+
+export interface VerifiedRefreshToken {
+  user: SessionUserView;
+  expiresAt: Date;
+}
+
+export interface SessionTokenManager {
+  createTokenPair(user: SessionUserView): SessionTokenPair;
+  verifyAccessToken(token: string): SessionUserView | null;
+  verifyRefreshToken(token: string): VerifiedRefreshToken | null;
+}
+
+export interface SessionLoginInput {
+  account: string;
+  password: string;
+}
+
+export interface SessionLogoutInput {
+  refreshToken: string;
+}
+
+export interface SessionRefreshInput {
+  refreshToken: string;
+}
+
+export interface SessionMeInput {
+  accessToken: string;
+}
+
+export interface SessionAuthResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  refreshExpiresIn: number;
+  user: SessionUserView;
+}
+
+export interface SessionAuthService {
+  login(input: SessionLoginInput): Promise<SessionAuthResult>;
+  refresh(input: SessionRefreshInput): Promise<SessionAuthResult>;
+  logout(input: SessionLogoutInput): Promise<void>;
+  getSessionUser(input: SessionMeInput): Promise<SessionUserView>;
+}
+
+export interface CreateSessionAuthServiceInput {
+  accountRepo: SessionAccountRepository;
+  refreshTokenRepo: SessionRefreshTokenRepository;
+  passwordVerifier: PasswordVerifier;
+  tokenManager: SessionTokenManager;
+}
+
+export class SessionAuthUnauthorizedError extends Error {
+  constructor() {
+    super("unauthorized");
+    this.name = "SessionAuthUnauthorizedError";
+  }
+}

--- a/src/modules/auth/unified-service.ts
+++ b/src/modules/auth/unified-service.ts
@@ -1,0 +1,203 @@
+import type { PasswordHasher, PasswordVerifier } from "./password.js";
+import type { AuthRole, AuthTokenSigner } from "./session-token.js";
+
+export interface UnifiedAuthAccountRecord {
+  role: Exclude<AuthRole, "admin">;
+  subjectId: string;
+  account: string;
+  displayName: string;
+  passwordHash: string | null;
+  status: "active" | "frozen";
+  mustChangePassword: boolean;
+  scope: {
+    schoolId?: number;
+    collegeId?: number;
+    majorId?: number;
+    classId?: number;
+  };
+  studentId?: number;
+  studentNo?: string;
+  teacherId?: string;
+}
+
+export interface UnifiedAuthRepository {
+  findByRoleAndAccount(role: Exclude<AuthRole, "admin">, account: string): Promise<UnifiedAuthAccountRecord | null>;
+  findByRoleAndSubjectId(role: Exclude<AuthRole, "admin">, subjectId: string): Promise<UnifiedAuthAccountRecord | null>;
+  updatePassword(input: {
+    role: Exclude<AuthRole, "admin">;
+    subjectId: string;
+    passwordHash: string;
+    mustChangePassword: boolean;
+  }): Promise<void>;
+}
+
+export interface UnifiedLoginInput {
+  role: AuthRole;
+  account: string;
+  password: string;
+}
+
+export interface UnifiedLoginResult {
+  token: string;
+  tokenType: "Bearer";
+  expiresIn: number;
+  role: AuthRole;
+  mustChangePassword: boolean;
+  displayName: string;
+}
+
+export interface UnifiedChangePasswordInput {
+  role: AuthRole;
+  subjectId: string;
+  oldPassword: string;
+  newPassword: string;
+}
+
+export interface UnifiedAuthService {
+  login(input: UnifiedLoginInput): Promise<UnifiedLoginResult>;
+  changePassword(input: UnifiedChangePasswordInput): Promise<void>;
+}
+
+export class UnifiedAuthUnauthorizedError extends Error {
+  constructor() {
+    super("invalid account or password");
+    this.name = "UnifiedAuthUnauthorizedError";
+  }
+}
+
+export class UnifiedAuthFrozenError extends Error {
+  constructor() {
+    super("account is frozen");
+    this.name = "UnifiedAuthFrozenError";
+  }
+}
+
+export class UnifiedAuthUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnifiedAuthUnsupportedError";
+  }
+}
+
+export class UnifiedAuthInvalidNewPasswordError extends Error {
+  constructor() {
+    super("newPassword is required and must be at least 8 characters");
+    this.name = "UnifiedAuthInvalidNewPasswordError";
+  }
+}
+
+export interface CreateUnifiedAuthServiceInput {
+  authRepo: UnifiedAuthRepository;
+  passwordVerifier: PasswordVerifier;
+  passwordHasher: PasswordHasher;
+  tokenSigner: AuthTokenSigner;
+  adminAccount: {
+    account: string;
+    password: string;
+  };
+}
+
+const DUMMY_PASSWORD_HASH = "$2b$10$ykqJ8CfeprKl2UpQm9a7ZOv9wZWyG2J.AoPTB5oTvbGdZyc/Ljcsm";
+
+const ensureValidNewPassword = (newPassword: string): void => {
+  if (newPassword.trim().length < 8) {
+    throw new UnifiedAuthInvalidNewPasswordError();
+  }
+};
+
+export const createUnifiedAuthService = ({
+  authRepo,
+  passwordVerifier,
+  passwordHasher,
+  tokenSigner,
+  adminAccount
+}: CreateUnifiedAuthServiceInput): UnifiedAuthService => {
+  return {
+    async login({ role, account, password }) {
+      const normalizedAccount = account.trim();
+
+      if (role === "admin") {
+        if (normalizedAccount !== adminAccount.account || password !== adminAccount.password) {
+          throw new UnifiedAuthUnauthorizedError();
+        }
+
+        return {
+          token: tokenSigner.signAuthToken({
+            sub: "admin",
+            role: "admin",
+            account: adminAccount.account,
+            displayName: "管理员",
+            schoolId: 1
+          }),
+          tokenType: "Bearer",
+          expiresIn: tokenSigner.expiresIn,
+          role: "admin",
+          mustChangePassword: false,
+          displayName: "管理员"
+        };
+      }
+
+      const record = await authRepo.findByRoleAndAccount(role, normalizedAccount);
+      const passwordHashForCompare = typeof record?.passwordHash === "string" ? record.passwordHash : DUMMY_PASSWORD_HASH;
+      const passwordMatched = await passwordVerifier.compare(password, passwordHashForCompare);
+
+      if (!record || !record.passwordHash || !passwordMatched) {
+        throw new UnifiedAuthUnauthorizedError();
+      }
+
+      if (record.status !== "active") {
+        throw new UnifiedAuthFrozenError();
+      }
+
+      return {
+        token: tokenSigner.signAuthToken({
+          sub: record.subjectId,
+          role,
+          account: record.account,
+          displayName: record.displayName,
+          studentId: record.studentId,
+          studentNo: record.studentNo,
+          teacherId: record.teacherId,
+          schoolId: record.scope.schoolId,
+          collegeId: record.scope.collegeId,
+          majorId: record.scope.majorId,
+          classId: record.scope.classId,
+          mustChangePassword: record.mustChangePassword
+        }),
+        tokenType: "Bearer",
+        expiresIn: tokenSigner.expiresIn,
+        role,
+        mustChangePassword: record.mustChangePassword,
+        displayName: record.displayName
+      };
+    },
+
+    async changePassword({ role, subjectId, oldPassword, newPassword }) {
+      if (role === "admin") {
+        throw new UnifiedAuthUnsupportedError("admin password is managed by system");
+      }
+
+      const record = await authRepo.findByRoleAndSubjectId(role, subjectId);
+      const passwordHashForCompare = typeof record?.passwordHash === "string" ? record.passwordHash : DUMMY_PASSWORD_HASH;
+      const oldPasswordMatched = await passwordVerifier.compare(oldPassword, passwordHashForCompare);
+
+      if (!record || !record.passwordHash || !oldPasswordMatched) {
+        throw new UnifiedAuthUnauthorizedError();
+      }
+
+      if (record.status !== "active") {
+        throw new UnifiedAuthFrozenError();
+      }
+
+      ensureValidNewPassword(newPassword);
+
+      const passwordHash = await passwordHasher.hash(newPassword);
+      await authRepo.updatePassword({
+        role,
+        subjectId,
+        passwordHash,
+        mustChangePassword: false
+      });
+    }
+  };
+};

--- a/src/modules/authorization/rbac.ts
+++ b/src/modules/authorization/rbac.ts
@@ -1,0 +1,38 @@
+import type { AuthRole } from "../auth/session-token.js";
+
+export const ROLE_PERMISSIONS: Record<AuthRole, string[]> = {
+  student: [
+    "student.profile.read",
+    "student.assessment.submit",
+    "report.read",
+    "task.read",
+    "task.checkin.submit",
+    "certificate.upload"
+  ],
+  teacher: [
+    "teacher.students.read",
+    "teacher.student.detail.read",
+    "teacher.activity.execute",
+    "report.read",
+    "task.read",
+    "student.profile.read"
+  ],
+  admin: [
+    "admin.org.manage",
+    "admin.teacher.manage",
+    "admin.authorization.manage",
+    "admin.activity.publish",
+    "admin.dashboard.read"
+  ]
+};
+
+export const hasPermissionByRole = ({
+  role,
+  permission
+}: {
+  role: AuthRole;
+  permission: string;
+}): boolean => {
+  const granted = ROLE_PERMISSIONS[role] ?? [];
+  return granted.includes(permission);
+};

--- a/src/modules/authorization/service.ts
+++ b/src/modules/authorization/service.ts
@@ -19,6 +19,9 @@ export type ResourceAuthorizationDecision =
   | { status: "forbidden"; studentId: number };
 
 export interface ResourceAuthorizationService {
+  findResourceStudentId(
+    input: Pick<AuthorizeTeacherResourceInput, "resourceType" | "resourceId">
+  ): Promise<number | null>;
   authorizeTeacherResource(
     input: AuthorizeTeacherResourceInput
   ): Promise<ResourceAuthorizationDecision>;
@@ -32,6 +35,9 @@ export const createResourceAuthorizationService = ({
   authorizationRepo
 }: CreateResourceAuthorizationServiceInput): ResourceAuthorizationService => {
   return {
+    async findResourceStudentId({ resourceType, resourceId }) {
+      return authorizationRepo.findResourceStudentId(resourceType, resourceId);
+    },
     async authorizeTeacherResource({
       teacherId,
       resourceType,

--- a/src/routes/admin.ts
+++ b/src/routes/admin.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context, type MiddlewareHandler } from "hono";
 import type {
   ActivityScopeType,
   ActivityService,
@@ -126,7 +126,9 @@ export interface AdminRouteDependencies {
       reason: string | null;
     }>;
   };
-  adminApiKey: string;
+  requirePermission?: (permission: string) => MiddlewareHandler;
+  resolveOperatorId?: (context: Context) => string;
+  adminApiKey?: string;
 }
 
 const isValidResetPasswordBody = (body: unknown): body is AdminResetPasswordRequestBody => {
@@ -256,8 +258,10 @@ const isValidPublishActivityBody = (body: unknown): body is AdminPublishActivity
   );
 };
 
-const isForbiddenByAdminKey = (requestAdminKey: string | undefined, adminApiKey: string): boolean => {
-  return !requestAdminKey || requestAdminKey !== adminApiKey;
+const passThroughPermission = (): MiddlewareHandler => {
+  return async (_, next) => {
+    await next();
+  };
 };
 
 const isDashboardDimension = (dimension: unknown): dimension is DashboardDimension => {
@@ -390,13 +394,12 @@ const resolveImportFile = (body: Record<string, unknown>): UploadedExcelFile | n
   return isUploadedExcelFile(fileField) ? fileField : null;
 };
 
-const resolveOperator = (rawOperator: string | undefined): string => {
-  if (!rawOperator) {
-    return "system-admin";
+const defaultResolveOperatorId = (context: Context): string => {
+  const auth = context.get("auth");
+  if (auth?.sub) {
+    return auth.sub;
   }
-
-  const operator = rawOperator.trim();
-  return operator.length > 0 ? operator : "system-admin";
+  return "system-admin";
 };
 
 const defaultExcelImportValidationService: Pick<ExcelImportValidationService, "validateExcelImport"> = {
@@ -473,17 +476,13 @@ export const createAdminRoutes = ({
   adminOrgService = defaultAdminOrgService,
   teacherAccountService = defaultTeacherAccountService,
   adminStudentArchiveService = defaultAdminStudentArchiveService,
-  adminApiKey
+  requirePermission = passThroughPermission,
+  resolveOperatorId = defaultResolveOperatorId
 }: AdminRouteDependencies) => {
   const admin = new Hono();
 
-  admin.post("/students/:id/reset-password", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
-
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+  admin.post("/students/:id/reset-password", requirePermission("admin.teacher.manage"), async (c) => {
+    const operator = resolveOperatorId(c);
     const studentId = parsePositiveInteger(c.req.param("id"));
 
     if (!studentId) {
@@ -527,11 +526,7 @@ export const createAdminRoutes = ({
     }
   });
 
-  admin.post("/org/colleges", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/org/colleges", requirePermission("admin.org.manage"), async (c) => {
 
     const body = (await c.req.json().catch(() => null)) as AdminCollegeCreateBody | null;
     if (!body || !Number.isInteger(body.schoolId) || body.schoolId <= 0 || !body.name?.trim()) {
@@ -545,11 +540,7 @@ export const createAdminRoutes = ({
     return c.json(result, 200);
   });
 
-  admin.patch("/org/colleges/:id", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.patch("/org/colleges/:id", requirePermission("admin.org.manage"), async (c) => {
 
     const collegeId = parsePositiveInteger(c.req.param("id"));
     const body = (await c.req.json().catch(() => null)) as AdminCollegeUpdateBody | null;
@@ -561,11 +552,7 @@ export const createAdminRoutes = ({
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.delete("/org/colleges/:id", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.delete("/org/colleges/:id", requirePermission("admin.org.manage"), async (c) => {
     const collegeId = parsePositiveInteger(c.req.param("id"));
     if (!collegeId) {
       return c.json({ message: "invalid college id" }, 400);
@@ -575,11 +562,7 @@ export const createAdminRoutes = ({
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.post("/teachers", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/teachers", requirePermission("admin.teacher.manage"), async (c) => {
 
     const body = (await c.req.json().catch(() => null)) as AdminTeacherCreateBody | null;
     if (
@@ -599,18 +582,14 @@ export const createAdminRoutes = ({
       status: body.status
     });
     await auditLogService.logActivityPublish({
-      operator: resolveOperator(c.req.header("x-admin-operator-id")),
+      operator: resolveOperatorId(c),
       activityType: "course",
-      title: `teacher_create:${result.teacherId}`
+      activityTitle: `teacher_create:${result.teacherId}`
     });
     return c.json(result, 200);
   });
 
-  admin.patch("/teachers/:id/status", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.patch("/teachers/:id/status", requirePermission("admin.teacher.manage"), async (c) => {
     const teacherId = c.req.param("id");
     const body = (await c.req.json().catch(() => null)) as AdminTeacherStatusBody | null;
     if (!teacherId?.trim() || !body || (body.status !== "active" && body.status !== "frozen")) {
@@ -622,18 +601,14 @@ export const createAdminRoutes = ({
       status: body.status
     });
     await auditLogService.logActivityPublish({
-      operator: resolveOperator(c.req.header("x-admin-operator-id")),
+      operator: resolveOperatorId(c),
       activityType: "course",
-      title: `teacher_status:${teacherId}:${body.status}`
+      activityTitle: `teacher_status:${teacherId}:${body.status}`
     });
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.post("/teachers/:id/reset-password", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/teachers/:id/reset-password", requirePermission("admin.teacher.manage"), async (c) => {
     const teacherId = c.req.param("id")?.trim();
     const body = (await c.req.json().catch(() => null)) as { newPassword?: string } | null;
     if (!teacherId || !body?.newPassword || body.newPassword.length < 8) {
@@ -645,17 +620,13 @@ export const createAdminRoutes = ({
       newPassword: body.newPassword
     });
     await auditLogService.logPasswordReset({
-      operator: resolveOperator(c.req.header("x-admin-operator-id")),
-      targetStudentId: 0
+      operator: resolveOperatorId(c),
+      studentId: 0
     });
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.post("/students", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/students", requirePermission("admin.org.manage"), async (c) => {
     const body = (await c.req.json().catch(() => null)) as AdminStudentArchiveCreateBody | null;
     if (
       !body ||
@@ -675,11 +646,7 @@ export const createAdminRoutes = ({
     return c.json(result, 200);
   });
 
-  admin.get("/students/:id", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/students/:id", requirePermission("admin.org.manage"), async (c) => {
     const studentId = parsePositiveInteger(c.req.param("id"));
     if (!studentId) {
       return c.json({ message: "invalid student id" }, 400);
@@ -691,11 +658,7 @@ export const createAdminRoutes = ({
     return c.json(result, 200);
   });
 
-  admin.patch("/students/:id", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.patch("/students/:id", requirePermission("admin.org.manage"), async (c) => {
     const studentId = parsePositiveInteger(c.req.param("id"));
     if (!studentId) {
       return c.json({ message: "invalid student id" }, 400);
@@ -704,19 +667,19 @@ export const createAdminRoutes = ({
     if (!body) {
       return c.json({ message: "invalid request body" }, 400);
     }
+    const classId =
+      Number.isInteger(body.classId) && typeof body.classId === "number" && body.classId > 0
+        ? body.classId
+        : undefined;
     await adminStudentArchiveService.updateStudentArchive({
       studentId,
       name: typeof body.name === "string" ? body.name.trim() : undefined,
-      classId: Number.isInteger(body.classId) && body.classId > 0 ? body.classId : undefined
+      classId
     });
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.delete("/students/:id", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.delete("/students/:id", requirePermission("admin.org.manage"), async (c) => {
     const studentId = parsePositiveInteger(c.req.param("id"));
     if (!studentId) {
       return c.json({ message: "invalid student id" }, 400);
@@ -725,11 +688,7 @@ export const createAdminRoutes = ({
     return c.json({ message: "ok" }, 200);
   });
 
-  admin.get("/students/:id/enrollment-link", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/students/:id/enrollment-link", requirePermission("admin.org.manage"), async (c) => {
     const studentId = parsePositiveInteger(c.req.param("id"));
     if (!studentId) {
       return c.json({ message: "invalid student id" }, 400);
@@ -738,13 +697,9 @@ export const createAdminRoutes = ({
     return c.json(result, 200);
   });
 
-  admin.post("/authorizations/grants", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/authorizations/grants", requirePermission("admin.authorization.manage"), async (c) => {
 
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const operator = resolveOperatorId(c);
 
     let body: unknown;
     try {
@@ -774,13 +729,9 @@ export const createAdminRoutes = ({
     return c.json({ message: "authorization granted" }, 200);
   });
 
-  admin.delete("/authorizations/grants", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.delete("/authorizations/grants", requirePermission("admin.authorization.manage"), async (c) => {
 
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const operator = resolveOperatorId(c);
 
     let body: unknown;
     try {
@@ -809,13 +760,9 @@ export const createAdminRoutes = ({
     return c.json({ message: "authorization revoked" }, 200);
   });
 
-  admin.post("/authorizations/grants/batch", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/authorizations/grants/batch", requirePermission("admin.authorization.manage"), async (c) => {
 
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const operator = resolveOperatorId(c);
 
     let body: unknown;
     try {
@@ -847,13 +794,9 @@ export const createAdminRoutes = ({
     return c.json({ message: "authorization granted", count: body.grants.length }, 200);
   });
 
-  admin.delete("/authorizations/grants/batch", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.delete("/authorizations/grants/batch", requirePermission("admin.authorization.manage"), async (c) => {
 
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const operator = resolveOperatorId(c);
 
     let body: unknown;
     try {
@@ -884,13 +827,9 @@ export const createAdminRoutes = ({
     return c.json({ message: "authorization revoked", count: body.grants.length }, 200);
   });
 
-  admin.post("/activities", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/activities", requirePermission("admin.activity.publish"), async (c) => {
 
-    const operator = resolveOperator(c.req.header("x-admin-operator-id"));
+    const operator = resolveOperatorId(c);
 
     let body: unknown;
     try {
@@ -923,11 +862,7 @@ export const createAdminRoutes = ({
     return c.json({ message: "activity published" }, 201);
   });
 
-  admin.get("/activities", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/activities", requirePermission("admin.activity.publish"), async (c) => {
 
     if (!activityService.listActivities) {
       return c.json({ message: "activity list service not configured" }, 500);
@@ -943,11 +878,7 @@ export const createAdminRoutes = ({
     }, 200);
   });
 
-  admin.post("/imports/excel/validate", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.post("/imports/excel/validate", requirePermission("admin.org.manage"), async (c) => {
 
     let body: Record<string, unknown>;
     try {
@@ -983,11 +914,7 @@ export const createAdminRoutes = ({
     }
   });
 
-  admin.get("/dashboard/dimension-aggregation", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/dashboard/dimension-aggregation", requirePermission("admin.dashboard.read"), async (c) => {
 
     const dimensionQuery = c.req.query("dimension");
     if (!isDashboardDimension(dimensionQuery)) {
@@ -1007,11 +934,7 @@ export const createAdminRoutes = ({
     return c.json(result, 200);
   });
 
-  admin.get("/dashboard/trend-funnel", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/dashboard/trend-funnel", requirePermission("admin.dashboard.read"), async (c) => {
 
     const { filters, hasInvalid } = resolveDashboardFiltersFromQuery((key) => c.req.query(key));
     if (hasInvalid || !filters) {
@@ -1046,11 +969,7 @@ export const createAdminRoutes = ({
     }
   });
 
-  admin.get("/dashboard/cockpit", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/dashboard/cockpit", requirePermission("admin.dashboard.read"), async (c) => {
 
     const dimensionQuery = c.req.query("dimension");
     const dimension: DashboardDimension = isDashboardDimension(dimensionQuery)
@@ -1108,11 +1027,7 @@ export const createAdminRoutes = ({
     }
   });
 
-  admin.get("/release/p0-baseline", async (c) => {
-    const requestAdminKey = c.req.header("x-admin-key");
-    if (isForbiddenByAdminKey(requestAdminKey, adminApiKey)) {
-      return c.json({ message: "forbidden" }, 403);
-    }
+  admin.get("/release/p0-baseline", requirePermission("admin.dashboard.read"), async (c) => {
 
     return c.json(
       {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,10 +1,15 @@
 import { Hono, type MiddlewareHandler } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
 import {
   InvalidNewPasswordError,
   StudentChangePasswordUnauthorizedError,
   StudentLoginUnauthorizedError,
   type StudentAuthService
 } from "../modules/auth/service.js";
+import {
+  SessionAuthUnauthorizedError,
+  type SessionAuthService
+} from "../modules/auth/session.js";
 import {
   StudentFirstLoginVerificationMismatchError,
   StudentFirstLoginVerificationNotFoundError,
@@ -22,6 +27,11 @@ interface StudentChangePasswordRequestBody {
   newPassword: string;
 }
 
+interface SessionLoginRequestBody {
+  account: string;
+  password: string;
+}
+
 interface StudentFirstLoginVerificationRequestBody {
   name: string;
   credentialNo: string;
@@ -31,6 +41,7 @@ interface StudentFirstLoginVerificationRequestBody {
 
 export interface AuthRouteDependencies {
   studentAuthService: StudentAuthService;
+  sessionAuthService?: SessionAuthService;
   studentFirstLoginVerificationService?: Pick<
     StudentFirstLoginVerificationService,
     "verifyStudentFirstLogin"
@@ -42,6 +53,10 @@ export interface AuthRouteDependencies {
 const passThroughAuthMiddleware: MiddlewareHandler = async (_, next) => {
   await next();
 };
+
+const REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
+const REFRESH_TOKEN_COOKIE_PATH = "/";
+const REFRESH_TOKEN_COOKIE_SAME_SITE = "Lax";
 
 const isValidLoginBody = (body: unknown): body is StudentLoginRequestBody => {
   if (!body || typeof body !== "object") {
@@ -72,6 +87,22 @@ const isValidChangePasswordBody = (body: unknown): body is StudentChangePassword
     oldPassword.length > 0 &&
     typeof newPassword === "string" &&
     newPassword.length > 0
+  );
+};
+
+const isValidSessionLoginBody = (body: unknown): body is SessionLoginRequestBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const account = (body as { account?: unknown }).account;
+  const password = (body as { password?: unknown }).password;
+
+  return (
+    typeof account === "string" &&
+    account.trim().length > 0 &&
+    typeof password === "string" &&
+    password.length > 0
   );
 };
 
@@ -114,13 +145,186 @@ const defaultEnrollmentProfileService: Pick<EnrollmentProfileService, "getEnroll
   }
 };
 
+const defaultSessionAuthService: SessionAuthService = {
+  async login() {
+    throw new Error("sessionAuthService is not configured");
+  },
+  async refresh() {
+    throw new Error("sessionAuthService is not configured");
+  },
+  async logout() {
+    throw new Error("sessionAuthService is not configured");
+  },
+  async getSessionUser() {
+    throw new Error("sessionAuthService is not configured");
+  }
+};
+
+const getRefreshCookieValue = (c: Parameters<MiddlewareHandler>[0]): string | null => {
+  const refreshToken = getCookie(c, REFRESH_TOKEN_COOKIE_KEY);
+  if (!refreshToken || refreshToken.trim().length === 0) {
+    return null;
+  }
+
+  return refreshToken;
+};
+
+const setRefreshCookie = ({
+  c,
+  refreshToken,
+  maxAge
+}: {
+  c: Parameters<MiddlewareHandler>[0];
+  refreshToken: string;
+  maxAge: number;
+}): void => {
+  setCookie(c, REFRESH_TOKEN_COOKIE_KEY, refreshToken, {
+    httpOnly: true,
+    sameSite: REFRESH_TOKEN_COOKIE_SAME_SITE,
+    path: REFRESH_TOKEN_COOKIE_PATH,
+    secure: process.env.NODE_ENV === "production",
+    maxAge
+  });
+};
+
+const clearRefreshCookie = (c: Parameters<MiddlewareHandler>[0]): void => {
+  deleteCookie(c, REFRESH_TOKEN_COOKIE_KEY, {
+    path: REFRESH_TOKEN_COOKIE_PATH
+  });
+};
+
+const getBearerToken = (authorizationHeader: string | undefined): string | null => {
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const matched = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+  if (!matched || !matched[1]) {
+    return null;
+  }
+
+  return matched[1].trim();
+};
+
 export const createAuthRoutes = ({
   studentAuthService,
+  sessionAuthService = defaultSessionAuthService,
   studentFirstLoginVerificationService = defaultStudentFirstLoginVerificationService,
   enrollmentProfileService = defaultEnrollmentProfileService,
   requireStudentAuth = passThroughAuthMiddleware
 }: AuthRouteDependencies) => {
   const auth = new Hono();
+
+  auth.post("/login", async (c) => {
+    let body: unknown;
+
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ message: "invalid request body" }, 400);
+    }
+
+    if (!isValidSessionLoginBody(body)) {
+      return c.json({ message: "account and password are required" }, 400);
+    }
+
+    try {
+      const result = await sessionAuthService.login({
+        account: body.account.trim(),
+        password: body.password
+      });
+      setRefreshCookie({
+        c,
+        refreshToken: result.refreshToken,
+        maxAge: result.refreshExpiresIn
+      });
+
+      return c.json(
+        {
+          accessToken: result.accessToken,
+          expiresIn: result.expiresIn,
+          user: result.user
+        },
+        200
+      );
+    } catch (error) {
+      if (error instanceof SessionAuthUnauthorizedError) {
+        return c.json({ message: "unauthorized" }, 401);
+      }
+
+      throw error;
+    }
+  });
+
+  auth.post("/refresh", async (c) => {
+    const refreshToken = getRefreshCookieValue(c);
+
+    if (!refreshToken) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    try {
+      const result = await sessionAuthService.refresh({
+        refreshToken
+      });
+      setRefreshCookie({
+        c,
+        refreshToken: result.refreshToken,
+        maxAge: result.refreshExpiresIn
+      });
+
+      return c.json(
+        {
+          accessToken: result.accessToken,
+          expiresIn: result.expiresIn,
+          user: result.user
+        },
+        200
+      );
+    } catch (error) {
+      if (error instanceof SessionAuthUnauthorizedError) {
+        return c.json({ message: "unauthorized" }, 401);
+      }
+
+      throw error;
+    }
+  });
+
+  auth.post("/logout", async (c) => {
+    const refreshToken = getRefreshCookieValue(c);
+
+    if (refreshToken) {
+      try {
+        await sessionAuthService.logout({ refreshToken });
+      } catch (error) {
+        if (!(error instanceof SessionAuthUnauthorizedError)) {
+          throw error;
+        }
+      }
+    }
+
+    clearRefreshCookie(c);
+    return c.json({ message: "logged out" }, 200);
+  });
+
+  auth.get("/me", async (c) => {
+    const authorization = c.req.header("authorization");
+    const accessToken = getBearerToken(authorization);
+    if (!accessToken) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    try {
+      const user = await sessionAuthService.getSessionUser({ accessToken });
+      return c.json(user, 200);
+    } catch (error) {
+      if (error instanceof SessionAuthUnauthorizedError) {
+        return c.json({ message: "unauthorized" }, 401);
+      }
+
+      throw error;
+    }
+  });
 
   auth.post("/student/login", async (c) => {
     let body: unknown;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -63,9 +63,23 @@ export interface AuthRouteDependencies {
 }
 
 const REFRESH_COOKIE_NAME = "refresh_token";
+const BEARER_TOKEN_PATTERN = /^bearer\s+(\S+)\s*$/i;
 
 const passThroughAuthMiddleware: MiddlewareHandler = async (_, next) => {
   await next();
+};
+
+const parseBearerToken = (authorizationHeader: string | undefined): string | null => {
+  if (!authorizationHeader) {
+    return null;
+  }
+
+  const matched = authorizationHeader.trim().match(BEARER_TOKEN_PATTERN);
+  if (!matched) {
+    return null;
+  }
+
+  return matched[1];
 };
 
 const isValidLoginBody = (body: unknown): body is StudentLoginRequestBody => {
@@ -191,6 +205,9 @@ const defaultSessionAuthService: SessionAuthService = {
   },
   async me() {
     throw new Error("sessionAuthService is not configured");
+  },
+  async getSessionUser() {
+    throw new Error("sessionAuthService is not configured");
   }
 };
 
@@ -229,11 +246,7 @@ export const createAuthRoutes = ({
         {
           accessToken: result.accessToken,
           expiresIn: result.expiresIn,
-          user: {
-            userId: result.user.userId,
-            role: result.user.role,
-            displayName: result.user.displayName
-          }
+          user: result.user
         },
         200
       );
@@ -268,11 +281,7 @@ export const createAuthRoutes = ({
         {
           accessToken: result.accessToken,
           expiresIn: result.expiresIn,
-          user: {
-            userId: result.user.userId,
-            role: result.user.role,
-            displayName: result.user.displayName
-          }
+          user: result.user
         },
         200
       );
@@ -294,34 +303,70 @@ export const createAuthRoutes = ({
       path: "/"
     });
 
-    return c.json({ message: "logout success" }, 200);
+    return c.json({ message: "logged out" }, 200);
   });
 
   auth.get("/me", requireAuth, async (c) => {
     const authInfo = c.get("auth");
-    if (!authInfo) {
+    if (authInfo) {
+      return c.json(
+        {
+          userId: authInfo.sub,
+          role: authInfo.role,
+          account: authInfo.account,
+          displayName: authInfo.displayName ?? authInfo.account,
+          studentId: authInfo.studentId,
+          studentNo: authInfo.studentNo,
+          teacherId: authInfo.teacherId,
+          mustChangePassword: authInfo.mustChangePassword ?? false,
+          scope: {
+            schoolId: authInfo.schoolId,
+            collegeId: authInfo.collegeId,
+            majorId: authInfo.majorId,
+            classId: authInfo.classId
+          }
+        },
+        200
+      );
+    }
+
+    const accessToken = parseBearerToken(c.req.header("authorization"));
+    if (!accessToken) {
       return c.json({ message: "unauthorized" }, 401);
     }
 
-    return c.json(
-      {
-        userId: authInfo.sub,
-        role: authInfo.role,
-        account: authInfo.account,
-        displayName: authInfo.displayName ?? authInfo.account,
-        studentId: authInfo.studentId,
-        studentNo: authInfo.studentNo,
-        teacherId: authInfo.teacherId,
-        mustChangePassword: authInfo.mustChangePassword ?? false,
-        scope: {
-          schoolId: authInfo.schoolId,
-          collegeId: authInfo.collegeId,
-          majorId: authInfo.majorId,
-          classId: authInfo.classId
+    if (typeof sessionAuthService.getSessionUser === "function") {
+      try {
+        const currentUser = await sessionAuthService.getSessionUser({ accessToken });
+        return c.json(currentUser, 200);
+      } catch (error) {
+        if (error instanceof SessionUnauthorizedError) {
+          return c.json({ message: "unauthorized" }, 401);
         }
-      },
-      200
-    );
+        throw error;
+      }
+    }
+
+    try {
+      const currentAuth = await sessionAuthService.me(accessToken);
+      return c.json(
+        {
+          userId: currentAuth.sub,
+          role: currentAuth.role,
+          account: currentAuth.account,
+          displayName: currentAuth.displayName ?? currentAuth.account,
+          studentId: currentAuth.studentId,
+          studentNo: currentAuth.studentNo,
+          teacherId: currentAuth.teacherId
+        },
+        200
+      );
+    } catch (error) {
+      if (error instanceof SessionUnauthorizedError) {
+        return c.json({ message: "unauthorized" }, 401);
+      }
+      throw error;
+    }
   });
 
   auth.post("/change-password", requireAuth, async (c) => {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,5 +1,5 @@
-import { Hono, type MiddlewareHandler } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { Hono, type MiddlewareHandler } from "hono";
 import {
   InvalidNewPasswordError,
   StudentChangePasswordUnauthorizedError,
@@ -7,15 +7,20 @@ import {
   type StudentAuthService
 } from "../modules/auth/service.js";
 import {
-  SessionAuthUnauthorizedError,
-  type SessionAuthService
-} from "../modules/auth/session.js";
-import {
   StudentFirstLoginVerificationMismatchError,
   StudentFirstLoginVerificationNotFoundError,
   type StudentFirstLoginVerificationService
 } from "../modules/auth/first-login-verification.js";
+import type { SessionAuthService } from "../modules/auth/session-service.js";
+import { SessionUnauthorizedError } from "../modules/auth/session-service.js";
 import type { EnrollmentProfileService } from "../modules/enrollment/profile.js";
+import {
+  UnifiedAuthFrozenError,
+  UnifiedAuthInvalidNewPasswordError,
+  UnifiedAuthUnauthorizedError,
+  UnifiedAuthUnsupportedError,
+  type UnifiedAuthService
+} from "../modules/auth/unified-service.js";
 
 interface StudentLoginRequestBody {
   studentNo: string;
@@ -27,11 +32,6 @@ interface StudentChangePasswordRequestBody {
   newPassword: string;
 }
 
-interface SessionLoginRequestBody {
-  account: string;
-  password: string;
-}
-
 interface StudentFirstLoginVerificationRequestBody {
   name: string;
   credentialNo: string;
@@ -39,24 +39,34 @@ interface StudentFirstLoginVerificationRequestBody {
   majorName: string;
 }
 
+interface UnifiedLoginRequestBody {
+  account: string;
+  password: string;
+}
+
+interface UnifiedChangePasswordRequestBody {
+  oldPassword: string;
+  newPassword: string;
+}
+
 export interface AuthRouteDependencies {
   studentAuthService: StudentAuthService;
-  sessionAuthService?: SessionAuthService;
   studentFirstLoginVerificationService?: Pick<
     StudentFirstLoginVerificationService,
     "verifyStudentFirstLogin"
   >;
   enrollmentProfileService?: Pick<EnrollmentProfileService, "getEnrollmentProfile">;
+  unifiedAuthService?: Pick<UnifiedAuthService, "changePassword">;
+  sessionAuthService?: SessionAuthService;
   requireStudentAuth?: MiddlewareHandler;
+  requireAuth?: MiddlewareHandler;
 }
+
+const REFRESH_COOKIE_NAME = "refresh_token";
 
 const passThroughAuthMiddleware: MiddlewareHandler = async (_, next) => {
   await next();
 };
-
-const REFRESH_TOKEN_COOKIE_KEY = "refresh_token";
-const REFRESH_TOKEN_COOKIE_PATH = "/";
-const REFRESH_TOKEN_COOKIE_SAME_SITE = "Lax";
 
 const isValidLoginBody = (body: unknown): body is StudentLoginRequestBody => {
   if (!body || typeof body !== "object") {
@@ -90,7 +100,7 @@ const isValidChangePasswordBody = (body: unknown): body is StudentChangePassword
   );
 };
 
-const isValidSessionLoginBody = (body: unknown): body is SessionLoginRequestBody => {
+const isValidUnifiedLoginBody = (body: unknown): body is UnifiedLoginRequestBody => {
   if (!body || typeof body !== "object") {
     return false;
   }
@@ -103,6 +113,24 @@ const isValidSessionLoginBody = (body: unknown): body is SessionLoginRequestBody
     account.trim().length > 0 &&
     typeof password === "string" &&
     password.length > 0
+  );
+};
+
+const isValidUnifiedChangePasswordBody = (
+  body: unknown
+): body is UnifiedChangePasswordRequestBody => {
+  if (!body || typeof body !== "object") {
+    return false;
+  }
+
+  const oldPassword = (body as { oldPassword?: unknown }).oldPassword;
+  const newPassword = (body as { newPassword?: unknown }).newPassword;
+
+  return (
+    typeof oldPassword === "string" &&
+    oldPassword.length > 0 &&
+    typeof newPassword === "string" &&
+    newPassword.length > 0
   );
 };
 
@@ -145,6 +173,12 @@ const defaultEnrollmentProfileService: Pick<EnrollmentProfileService, "getEnroll
   }
 };
 
+const defaultUnifiedAuthService: Pick<UnifiedAuthService, "changePassword"> = {
+  async changePassword() {
+    throw new Error("unifiedAuthService is not configured");
+  }
+};
+
 const defaultSessionAuthService: SessionAuthService = {
   async login() {
     throw new Error("sessionAuthService is not configured");
@@ -155,77 +189,26 @@ const defaultSessionAuthService: SessionAuthService = {
   async logout() {
     throw new Error("sessionAuthService is not configured");
   },
-  async getSessionUser() {
+  async me() {
     throw new Error("sessionAuthService is not configured");
   }
 };
 
-const getRefreshCookieValue = (c: Parameters<MiddlewareHandler>[0]): string | null => {
-  const refreshToken = getCookie(c, REFRESH_TOKEN_COOKIE_KEY);
-  if (!refreshToken || refreshToken.trim().length === 0) {
-    return null;
-  }
-
-  return refreshToken;
-};
-
-const setRefreshCookie = ({
-  c,
-  refreshToken,
-  maxAge
-}: {
-  c: Parameters<MiddlewareHandler>[0];
-  refreshToken: string;
-  maxAge: number;
-}): void => {
-  setCookie(c, REFRESH_TOKEN_COOKIE_KEY, refreshToken, {
-    httpOnly: true,
-    sameSite: REFRESH_TOKEN_COOKIE_SAME_SITE,
-    path: REFRESH_TOKEN_COOKIE_PATH,
-    secure: process.env.NODE_ENV === "production",
-    maxAge
-  });
-};
-
-const clearRefreshCookie = (c: Parameters<MiddlewareHandler>[0]): void => {
-  deleteCookie(c, REFRESH_TOKEN_COOKIE_KEY, {
-    path: REFRESH_TOKEN_COOKIE_PATH
-  });
-};
-
-const getBearerToken = (authorizationHeader: string | undefined): string | null => {
-  if (!authorizationHeader) {
-    return null;
-  }
-
-  const matched = authorizationHeader.match(/^Bearer\s+(.+)$/i);
-  if (!matched || !matched[1]) {
-    return null;
-  }
-
-  return matched[1].trim();
-};
-
 export const createAuthRoutes = ({
   studentAuthService,
-  sessionAuthService = defaultSessionAuthService,
   studentFirstLoginVerificationService = defaultStudentFirstLoginVerificationService,
   enrollmentProfileService = defaultEnrollmentProfileService,
-  requireStudentAuth = passThroughAuthMiddleware
+  unifiedAuthService = defaultUnifiedAuthService,
+  sessionAuthService = defaultSessionAuthService,
+  requireStudentAuth = passThroughAuthMiddleware,
+  requireAuth = passThroughAuthMiddleware
 }: AuthRouteDependencies) => {
   const auth = new Hono();
 
   auth.post("/login", async (c) => {
-    let body: unknown;
-
-    try {
-      body = await c.req.json();
-    } catch {
-      return c.json({ message: "invalid request body" }, 400);
-    }
-
-    if (!isValidSessionLoginBody(body)) {
-      return c.json({ message: "account and password are required" }, 400);
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    if (!isValidUnifiedLoginBody(body)) {
+      return c.json({ message: "account/password is required" }, 400);
     }
 
     try {
@@ -233,9 +216,12 @@ export const createAuthRoutes = ({
         account: body.account.trim(),
         password: body.password
       });
-      setRefreshCookie({
-        c,
-        refreshToken: result.refreshToken,
+
+      setCookie(c, REFRESH_COOKIE_NAME, result.refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "Strict",
+        path: "/",
         maxAge: result.refreshExpiresIn
       });
 
@@ -243,33 +229,38 @@ export const createAuthRoutes = ({
         {
           accessToken: result.accessToken,
           expiresIn: result.expiresIn,
-          user: result.user
+          user: {
+            userId: result.user.userId,
+            role: result.user.role,
+            displayName: result.user.displayName
+          }
         },
         200
       );
     } catch (error) {
-      if (error instanceof SessionAuthUnauthorizedError) {
+      if (error instanceof SessionUnauthorizedError || error instanceof UnifiedAuthUnauthorizedError) {
         return c.json({ message: "unauthorized" }, 401);
       }
-
+      if (error instanceof UnifiedAuthFrozenError) {
+        return c.json({ message: error.message }, 403);
+      }
       throw error;
     }
   });
 
   auth.post("/refresh", async (c) => {
-    const refreshToken = getRefreshCookieValue(c);
-
+    const refreshToken = getCookie(c, REFRESH_COOKIE_NAME);
     if (!refreshToken) {
       return c.json({ message: "unauthorized" }, 401);
     }
 
     try {
-      const result = await sessionAuthService.refresh({
-        refreshToken
-      });
-      setRefreshCookie({
-        c,
-        refreshToken: result.refreshToken,
+      const result = await sessionAuthService.refresh(refreshToken);
+      setCookie(c, REFRESH_COOKIE_NAME, result.refreshToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "Strict",
+        path: "/",
         maxAge: result.refreshExpiresIn
       });
 
@@ -277,55 +268,97 @@ export const createAuthRoutes = ({
         {
           accessToken: result.accessToken,
           expiresIn: result.expiresIn,
-          user: result.user
+          user: {
+            userId: result.user.userId,
+            role: result.user.role,
+            displayName: result.user.displayName
+          }
         },
         200
       );
     } catch (error) {
-      if (error instanceof SessionAuthUnauthorizedError) {
+      if (error instanceof SessionUnauthorizedError) {
         return c.json({ message: "unauthorized" }, 401);
       }
-
       throw error;
     }
   });
 
   auth.post("/logout", async (c) => {
-    const refreshToken = getRefreshCookieValue(c);
-
+    const refreshToken = getCookie(c, REFRESH_COOKIE_NAME);
     if (refreshToken) {
-      try {
-        await sessionAuthService.logout({ refreshToken });
-      } catch (error) {
-        if (!(error instanceof SessionAuthUnauthorizedError)) {
-          throw error;
-        }
-      }
+      await sessionAuthService.logout(refreshToken).catch(() => undefined);
     }
 
-    clearRefreshCookie(c);
-    return c.json({ message: "logged out" }, 200);
+    deleteCookie(c, REFRESH_COOKIE_NAME, {
+      path: "/"
+    });
+
+    return c.json({ message: "logout success" }, 200);
   });
 
-  auth.get("/me", async (c) => {
-    const authorization = c.req.header("authorization");
-    const accessToken = getBearerToken(authorization);
-    if (!accessToken) {
+  auth.get("/me", requireAuth, async (c) => {
+    const authInfo = c.get("auth");
+    if (!authInfo) {
       return c.json({ message: "unauthorized" }, 401);
     }
 
-    try {
-      const user = await sessionAuthService.getSessionUser({ accessToken });
-      return c.json(user, 200);
-    } catch (error) {
-      if (error instanceof SessionAuthUnauthorizedError) {
-        return c.json({ message: "unauthorized" }, 401);
-      }
+    return c.json(
+      {
+        userId: authInfo.sub,
+        role: authInfo.role,
+        account: authInfo.account,
+        displayName: authInfo.displayName ?? authInfo.account,
+        studentId: authInfo.studentId,
+        studentNo: authInfo.studentNo,
+        teacherId: authInfo.teacherId,
+        mustChangePassword: authInfo.mustChangePassword ?? false,
+        scope: {
+          schoolId: authInfo.schoolId,
+          collegeId: authInfo.collegeId,
+          majorId: authInfo.majorId,
+          classId: authInfo.classId
+        }
+      },
+      200
+    );
+  });
 
+  auth.post("/change-password", requireAuth, async (c) => {
+    const authInfo = c.get("auth");
+    if (!authInfo) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    if (!isValidUnifiedChangePasswordBody(body)) {
+      return c.json({ message: "oldPassword and newPassword are required" }, 400);
+    }
+
+    try {
+      await unifiedAuthService.changePassword({
+        role: authInfo.role,
+        subjectId: authInfo.sub,
+        oldPassword: body.oldPassword,
+        newPassword: body.newPassword
+      });
+
+      return c.json({ message: "password changed" }, 200);
+    } catch (error) {
+      if (error instanceof UnifiedAuthUnauthorizedError) {
+        return c.json({ message: error.message }, 401);
+      }
+      if (error instanceof UnifiedAuthFrozenError) {
+        return c.json({ message: error.message }, 403);
+      }
+      if (error instanceof UnifiedAuthInvalidNewPasswordError || error instanceof UnifiedAuthUnsupportedError) {
+        return c.json({ message: error.message }, 400);
+      }
       throw error;
     }
   });
 
+  // 兼容已存在 student 流程（首登校验/画像等），逐步迁移中。
   auth.post("/student/login", async (c) => {
     let body: unknown;
 

--- a/src/routes/teacher.ts
+++ b/src/routes/teacher.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context, type MiddlewareHandler } from "hono";
 import type {
   AssessmentStatusFilter,
   ReportStatusFilter,
@@ -18,7 +18,23 @@ export interface TeacherRouteDependencies {
   teacherMyStudentsService: Pick<TeacherMyStudentsService, "getMyStudents">;
   teacherStudentDetailService?: Pick<TeacherStudentDetailService, "getStudentDetail">;
   teacherActivityExecutionService?: Pick<TeacherActivityExecutionService, "executeActivity">;
+  requirePermission?: (permission: string) => MiddlewareHandler;
+  resolveTeacherId?: (context: Context) => string | null;
 }
+
+const passThroughPermission = (): MiddlewareHandler => {
+  return async (_, next) => {
+    await next();
+  };
+};
+
+const defaultResolveTeacherId = (c: Context): string | null => {
+  const auth = c.get("auth");
+  if (!auth || auth.role !== "teacher" || !auth.teacherId) {
+    return null;
+  }
+  return auth.teacherId;
+};
 
 const parsePositiveInteger = (raw: string | undefined): number | undefined => {
   if (raw === undefined) {
@@ -55,14 +71,16 @@ export const createTeacherRoutes = ({
     async executeActivity() {
       throw new Error("teacherActivityExecutionService is not configured");
     }
-  }
+  },
+  requirePermission = passThroughPermission,
+  resolveTeacherId = defaultResolveTeacherId
 }: TeacherRouteDependencies) => {
   const teacher = new Hono();
 
-  teacher.get("/my-students", async (c) => {
-    const teacherId = c.req.header("x-teacher-id")?.trim();
+  teacher.get("/my-students", requirePermission("teacher.students.read"), async (c) => {
+    const teacherId = resolveTeacherId(c);
     if (!teacherId) {
-      return c.json({ message: "teacher id required" }, 401);
+      return c.json({ message: "unauthorized" }, 401);
     }
 
     const page = parsePositiveInteger(c.req.query("page")) ?? 1;
@@ -84,10 +102,10 @@ export const createTeacherRoutes = ({
     return c.json(result, 200);
   });
 
-  teacher.get("/students/:id/detail", async (c) => {
-    const teacherId = c.req.header("x-teacher-id")?.trim();
+  teacher.get("/students/:id/detail", requirePermission("teacher.student.detail.read"), async (c) => {
+    const teacherId = resolveTeacherId(c);
     if (!teacherId) {
-      return c.json({ message: "teacher id required" }, 401);
+      return c.json({ message: "unauthorized" }, 401);
     }
 
     const studentId = Number.parseInt(c.req.param("id"), 10);
@@ -112,10 +130,10 @@ export const createTeacherRoutes = ({
     }
   });
 
-  teacher.post("/activities/:id/execute", async (c) => {
-    const teacherId = c.req.header("x-teacher-id")?.trim();
+  teacher.post("/activities/:id/execute", requirePermission("teacher.activity.execute"), async (c) => {
+    const teacherId = resolveTeacherId(c);
     if (!teacherId) {
-      return c.json({ message: "teacher id required" }, 401);
+      return c.json({ message: "unauthorized" }, 401);
     }
 
     const activityId = Number.parseInt(c.req.param("id"), 10);

--- a/tests/admin/org-teacher-account.test.ts
+++ b/tests/admin/org-teacher-account.test.ts
@@ -3,6 +3,15 @@ import assert from "node:assert/strict";
 import { Hono } from "hono";
 import { createAdminRoutes } from "../../src/routes/admin.ts";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    if (c.req.header("x-admin-key") !== "admin-key") {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
 const baseDependencies = {
   studentAuthService: {
     async resetStudentPasswordByAdmin() {
@@ -36,7 +45,8 @@ const baseDependencies = {
       return;
     }
   },
-  adminApiKey: "admin-key"
+  adminApiKey: "admin-key",
+  requirePermission: requireAdminPermission
 } as const;
 
 test("admin org CRUD should require admin key", async () => {

--- a/tests/auth/admin-reset-password.test.ts
+++ b/tests/auth/admin-reset-password.test.ts
@@ -11,6 +11,15 @@ import {
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    if (c.req.header("x-admin-key") !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
 interface TestContext {
   student: StudentAuthRecord | null;
   updateInputs: StudentPasswordUpdateInput[];
@@ -88,7 +97,8 @@ function buildApp(ctx: TestContext): Hono {
           ctx.auditActions.push("activity_publish");
         }
       },
-      adminApiKey
+      adminApiKey,
+      requirePermission: requireAdminPermission
     })
   );
 

--- a/tests/auth/resource-authorization.test.ts
+++ b/tests/auth/resource-authorization.test.ts
@@ -37,6 +37,20 @@ const createApp = (fixture: AuthorizationFixture) => {
   });
 
   const app = new Hono();
+  app.use("/resources/*", async (c, next) => {
+    const teacherId = c.req.header("x-teacher-id") ?? c.req.header("X-Teacher-Id");
+    if (!teacherId) {
+      return c.json({ message: "unauthorized" }, 401);
+    }
+
+    c.set("auth", {
+      sub: teacherId,
+      role: "teacher",
+      account: teacherId,
+      teacherId
+    });
+    await next();
+  });
 
   app.route(
     "/resources",
@@ -44,7 +58,8 @@ const createApp = (fixture: AuthorizationFixture) => {
       createResourceAuthorization: (resourceType) =>
         createResourceAuthorizationMiddleware({
           resourceType,
-          authorizationService: service
+          authorizationService: service,
+          hasPermission: () => true
         })
     })
   );

--- a/tests/auth/session-service.test.ts
+++ b/tests/auth/session-service.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import bcrypt from "bcryptjs";
+import { bcryptPasswordVerifier } from "../../src/modules/auth/password.ts";
+import { createSessionAuthService } from "../../src/modules/auth/session-service.ts";
+import { createJwtSessionTokenManager } from "../../src/modules/auth/session-token.ts";
+import {
+  SessionAuthUnauthorizedError,
+  type SessionAccountRecord,
+  type SessionRefreshTokenRecord
+} from "../../src/modules/auth/session.ts";
+
+interface SessionTestContext {
+  account: SessionAccountRecord;
+  refreshTokenRecords: Map<string, SessionRefreshTokenRecord>;
+}
+
+const testJwtSecret = "s".repeat(32);
+
+const hashRefreshToken = (token: string): string => {
+  return createHash("sha256").update(token).digest("hex");
+};
+
+const buildContext = async (): Promise<SessionTestContext> => {
+  return {
+    account: {
+      userId: "teacher:T-001",
+      role: "teacher",
+      account: "teacher.chen",
+      name: "陈老师",
+      teacherId: "T-001",
+      passwordHash: await bcrypt.hash("Passw0rd!", 4),
+      status: "active"
+    },
+    refreshTokenRecords: new Map<string, SessionRefreshTokenRecord>()
+  };
+};
+
+const createService = (ctx: SessionTestContext) => {
+  return createSessionAuthService({
+    accountRepo: {
+      async findByAccount(account) {
+        return account === ctx.account.account ? ctx.account : null;
+      }
+    },
+    refreshTokenRepo: {
+      async save(record) {
+        ctx.refreshTokenRecords.set(record.tokenHash, record);
+      },
+      async findByTokenHash(tokenHash) {
+        return ctx.refreshTokenRecords.get(tokenHash) ?? null;
+      },
+      async revokeByTokenHash(tokenHash, revokedAt) {
+        const existing = ctx.refreshTokenRecords.get(tokenHash);
+        if (!existing) {
+          return;
+        }
+
+        ctx.refreshTokenRecords.set(tokenHash, {
+          ...existing,
+          revokedAt
+        });
+      }
+    },
+    passwordVerifier: bcryptPasswordVerifier,
+    tokenManager: createJwtSessionTokenManager({
+      secret: testJwtSecret,
+      accessExpiresInSeconds: 60,
+      refreshExpiresInSeconds: 300
+    })
+  });
+};
+
+test("session service login should issue token pair and persist hashed refresh token", async () => {
+  const ctx = await buildContext();
+  const service = createService(ctx);
+  const result = await service.login({
+    account: "teacher.chen",
+    password: "Passw0rd!"
+  });
+
+  assert.equal(typeof result.accessToken, "string");
+  assert.equal(typeof result.refreshToken, "string");
+  assert.equal(result.user.userId, "teacher:T-001");
+  assert.equal(ctx.refreshTokenRecords.size, 1);
+
+  const savedHashes = [...ctx.refreshTokenRecords.keys()];
+  assert.equal(savedHashes.length, 1);
+  assert.equal(savedHashes[0], hashRefreshToken(result.refreshToken));
+  assert.equal(savedHashes[0].length, 64);
+});
+
+test("session service login should reject invalid password", async () => {
+  const ctx = await buildContext();
+  const service = createService(ctx);
+
+  await assert.rejects(
+    async () => {
+      await service.login({
+        account: "teacher.chen",
+        password: "WrongPass1!"
+      });
+    },
+    (error) => error instanceof SessionAuthUnauthorizedError
+  );
+});
+
+test("session service refresh should rotate refresh token and revoke previous token", async () => {
+  const ctx = await buildContext();
+  const service = createService(ctx);
+
+  const firstLoginResult = await service.login({
+    account: "teacher.chen",
+    password: "Passw0rd!"
+  });
+  const firstTokenHash = hashRefreshToken(firstLoginResult.refreshToken);
+
+  const refreshedResult = await service.refresh({
+    refreshToken: firstLoginResult.refreshToken
+  });
+  const secondTokenHash = hashRefreshToken(refreshedResult.refreshToken);
+
+  assert.notEqual(firstTokenHash, secondTokenHash);
+  assert.equal(ctx.refreshTokenRecords.size, 2);
+  assert.ok(ctx.refreshTokenRecords.get(firstTokenHash)?.revokedAt);
+  assert.equal(ctx.refreshTokenRecords.get(secondTokenHash)?.revokedAt, null);
+
+  await assert.rejects(
+    async () => {
+      await service.refresh({
+        refreshToken: firstLoginResult.refreshToken
+      });
+    },
+    (error) => error instanceof SessionAuthUnauthorizedError
+  );
+});
+
+test("session service logout should revoke existing refresh token", async () => {
+  const ctx = await buildContext();
+  const service = createService(ctx);
+
+  const loginResult = await service.login({
+    account: "teacher.chen",
+    password: "Passw0rd!"
+  });
+  const tokenHash = hashRefreshToken(loginResult.refreshToken);
+
+  await service.logout({
+    refreshToken: loginResult.refreshToken
+  });
+
+  assert.ok(ctx.refreshTokenRecords.get(tokenHash)?.revokedAt);
+});
+
+test("session service me should return user from access token", async () => {
+  const ctx = await buildContext();
+  const service = createService(ctx);
+  const loginResult = await service.login({
+    account: "teacher.chen",
+    password: "Passw0rd!"
+  });
+
+  const user = await service.getSessionUser({
+    accessToken: loginResult.accessToken
+  });
+
+  assert.deepEqual(user, {
+    userId: "teacher:T-001",
+    role: "teacher",
+    account: "teacher.chen",
+    name: "陈老师",
+    teacherId: "T-001",
+    studentNo: undefined,
+    studentId: undefined
+  });
+});

--- a/tests/auth/unified-auth-route.test.ts
+++ b/tests/auth/unified-auth-route.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Hono } from "hono";
+import { createAuthRoutes } from "../../src/routes/auth.ts";
+import type { SessionAuthService, SessionUserView } from "../../src/modules/auth/session.ts";
+
+const loginPath = "/auth/login";
+const refreshPath = "/auth/refresh";
+const logoutPath = "/auth/logout";
+const mePath = "/auth/me";
+const refreshCookieValue = "refresh-token-001";
+
+const currentUser: SessionUserView = {
+  userId: "teacher:T-100",
+  role: "teacher",
+  account: "teacher.chen",
+  name: "陈老师",
+  teacherId: "T-100"
+};
+
+const baseStudentAuthService = {
+  async loginStudent() {
+    return { token: "unused", expiresIn: 1, mustChangePassword: false };
+  },
+  async changeStudentPassword() {
+    return;
+  },
+  async resetStudentPasswordByAdmin() {
+    return;
+  }
+};
+
+const createSessionAuthServiceStub = (): SessionAuthService => {
+  return {
+    async login() {
+      return {
+        accessToken: "access-token-001",
+        refreshToken: refreshCookieValue,
+        expiresIn: 900,
+        refreshExpiresIn: 3600,
+        user: currentUser
+      };
+    },
+    async refresh() {
+      return {
+        accessToken: "access-token-002",
+        refreshToken: "refresh-token-002",
+        expiresIn: 900,
+        refreshExpiresIn: 3600,
+        user: currentUser
+      };
+    },
+    async logout() {
+      return;
+    },
+    async getSessionUser() {
+      return currentUser;
+    }
+  };
+};
+
+const mountAuthApp = (): Hono => {
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: baseStudentAuthService,
+      sessionAuthService: createSessionAuthServiceStub()
+    })
+  );
+
+  return app;
+};
+
+test("POST /auth/login should return access token and set refresh cookie", async () => {
+  const app = mountAuthApp();
+  const response = await app.request(loginPath, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      account: "teacher.chen",
+      password: "Passw0rd!"
+    })
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    accessToken: "access-token-001",
+    expiresIn: 900,
+    user: currentUser
+  });
+
+  const setCookieHeader = response.headers.get("set-cookie");
+  assert.ok(setCookieHeader);
+  assert.equal(setCookieHeader.includes("refresh_token=refresh-token-001"), true);
+  assert.equal(setCookieHeader.includes("HttpOnly"), true);
+});
+
+test("POST /auth/refresh should return 401 when refresh cookie is missing", async () => {
+  const app = mountAuthApp();
+  const response = await app.request(refreshPath, {
+    method: "POST"
+  });
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    message: "unauthorized"
+  });
+});
+
+test("POST /auth/logout should clear refresh cookie", async () => {
+  const app = mountAuthApp();
+  const response = await app.request(logoutPath, {
+    method: "POST",
+    headers: {
+      cookie: "refresh_token=refresh-token-001"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    message: "logged out"
+  });
+  const setCookieHeader = response.headers.get("set-cookie");
+  assert.ok(setCookieHeader);
+  assert.equal(setCookieHeader.includes("refresh_token="), true);
+});
+
+test("GET /auth/me should return current user by Bearer token", async () => {
+  const app = mountAuthApp();
+  const response = await app.request(mePath, {
+    method: "GET",
+    headers: {
+      authorization: "Bearer access-token-001"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), currentUser);
+});

--- a/tests/auth/unified-auth-routes.test.ts
+++ b/tests/auth/unified-auth-routes.test.ts
@@ -1,0 +1,263 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Hono, type MiddlewareHandler } from "hono";
+import { createAuthRoutes } from "../../src/routes/auth.ts";
+import { SessionUnauthorizedError } from "../../src/modules/auth/session-service.ts";
+import {
+  UnifiedAuthFrozenError,
+  UnifiedAuthUnauthorizedError,
+  UnifiedAuthUnsupportedError
+} from "../../src/modules/auth/unified-service.ts";
+
+const requireAuth: MiddlewareHandler = async (c, next) => {
+  const authHeader = c.req.header("authorization");
+  if (authHeader !== "Bearer valid-token") {
+    return c.json({ message: "unauthorized" }, 401);
+  }
+
+  c.set("auth", {
+    sub: "T-1",
+    role: "teacher",
+    account: "teacher001",
+    teacherId: "T-1",
+    displayName: "张老师"
+  });
+
+  await next();
+};
+
+const buildApp = () => {
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          return { token: "student-token", expiresIn: 3600, mustChangePassword: false };
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      sessionAuthService: {
+        async login({ account, password }) {
+          if (account === "teacher001" && password === "Passw0rd!") {
+            return {
+              accessToken: "valid-token",
+              expiresIn: 3600,
+              refreshToken: "refresh-token",
+              refreshExpiresIn: 2592000,
+              user: {
+                userId: "T-1",
+                role: "teacher",
+                displayName: "张老师",
+                account: "teacher001"
+              }
+            };
+          }
+          throw new SessionUnauthorizedError();
+        },
+        async refresh(refreshToken) {
+          if (refreshToken !== "refresh-token") {
+            throw new SessionUnauthorizedError();
+          }
+          return {
+            accessToken: "valid-token",
+            expiresIn: 3600,
+            refreshToken: "refresh-token-2",
+            refreshExpiresIn: 2592000,
+            user: {
+              userId: "T-1",
+              role: "teacher",
+              displayName: "张老师",
+              account: "teacher001"
+            }
+          };
+        },
+        async logout() {
+          return;
+        },
+        async me() {
+          return {
+            sub: "T-1",
+            role: "teacher",
+            account: "teacher001"
+          };
+        }
+      },
+      unifiedAuthService: {
+        async changePassword({ role, subjectId, oldPassword, newPassword }) {
+          if (role !== "teacher" || subjectId !== "T-1") {
+            throw new UnifiedAuthUnauthorizedError();
+          }
+          if (oldPassword !== "Passw0rd!") {
+            throw new UnifiedAuthUnauthorizedError();
+          }
+          if (newPassword.length < 8) {
+            throw new UnifiedAuthUnsupportedError("new password too short");
+          }
+        }
+      },
+      requireAuth
+    })
+  );
+
+  return app;
+};
+
+test("POST /auth/login should support unified teacher login", async () => {
+  const app = buildApp();
+
+  const response = await app.request("/auth/login", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      account: "teacher001",
+      password: "Passw0rd!"
+    })
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.user.role, "teacher");
+  assert.equal(payload.accessToken, "valid-token");
+});
+
+test("POST /auth/login should return 401 on invalid account/password", async () => {
+  const app = buildApp();
+
+  const response = await app.request("/auth/login", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      account: "teacher001",
+      password: "wrong"
+    })
+  });
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), {
+    message: "unauthorized"
+  });
+});
+
+test("GET /auth/me should require bearer token", async () => {
+  const app = buildApp();
+
+  const unauthorized = await app.request("/auth/me");
+  assert.equal(unauthorized.status, 401);
+
+  const response = await app.request("/auth/me", {
+    headers: {
+      authorization: "Bearer valid-token"
+    }
+  });
+
+  assert.equal(response.status, 200);
+  const payload = await response.json();
+  assert.equal(payload.role, "teacher");
+  assert.equal(payload.teacherId, "T-1");
+});
+
+test("POST /auth/change-password should validate and call unified auth service", async () => {
+  const app = buildApp();
+
+  const success = await app.request("/auth/change-password", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      oldPassword: "Passw0rd!",
+      newPassword: "NewPass2@"
+    })
+  });
+  assert.equal(success.status, 200);
+
+  const failed = await app.request("/auth/change-password", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      oldPassword: "wrong",
+      newPassword: "NewPass2@"
+    })
+  });
+  assert.equal(failed.status, 401);
+
+  const unsupported = await app.request("/auth/change-password", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer valid-token",
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      oldPassword: "Passw0rd!",
+      newPassword: "short"
+    })
+  });
+  assert.equal(unsupported.status, 400);
+});
+
+test("POST /auth/login should return 403 when account is frozen", async () => {
+  const app = new Hono();
+  app.route(
+    "/auth",
+    createAuthRoutes({
+      studentAuthService: {
+        async loginStudent() {
+          return { token: "student-token", expiresIn: 3600, mustChangePassword: false };
+        },
+        async changeStudentPassword() {
+          return;
+        },
+        async resetStudentPasswordByAdmin() {
+          return;
+        }
+      },
+      sessionAuthService: {
+        async login() {
+          throw new UnifiedAuthFrozenError();
+        },
+        async refresh() {
+          throw new SessionUnauthorizedError();
+        },
+        async logout() {
+          return;
+        },
+        async me() {
+          throw new SessionUnauthorizedError();
+        }
+      },
+      unifiedAuthService: {
+        async changePassword() {
+          return;
+        }
+      },
+      requireAuth
+    })
+  );
+
+  const response = await app.request("/auth/login", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json"
+    },
+    body: JSON.stringify({
+      account: "teacher001",
+      password: "Passw0rd!"
+    })
+  });
+
+  assert.equal(response.status, 403);
+});

--- a/tests/import/admin-excel-import.test.ts
+++ b/tests/import/admin-excel-import.test.ts
@@ -11,6 +11,16 @@ import {
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    const requestAdminKey = c.req.header("x-admin-key") ?? c.req.header("X-Admin-Key");
+    if (requestAdminKey !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
 interface Fixture {
   calls: Array<{ datasetType: "enrollment" | "employment" }>;
 }
@@ -57,7 +67,8 @@ const createNoopAdminApp = (
         }
       },
       excelImportValidationService,
-      adminApiKey
+      adminApiKey,
+      requirePermission: requireAdminPermission
     })
   );
 

--- a/tests/integration/activity-flow.test.ts
+++ b/tests/integration/activity-flow.test.ts
@@ -13,6 +13,22 @@ interface ActivityFlowStore {
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    if (c.req.header("x-admin-key") !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 const buildApp = (store: ActivityFlowStore) => {
   const app = new Hono();
 
@@ -56,7 +72,7 @@ const buildApp = (store: ActivityFlowStore) => {
           return;
         }
       },
-      adminApiKey
+      requirePermission: requireAdminPermission
     })
   );
 
@@ -82,7 +98,8 @@ const buildApp = (store: ActivityFlowStore) => {
           store.executionRecords.push({ activityId: input.activityId, teacherId: input.teacherId });
           return { recordId: store.executionRecords.length, status: "submitted" as const };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 

--- a/tests/integration/auth-flow.test.ts
+++ b/tests/integration/auth-flow.test.ts
@@ -11,6 +11,22 @@ interface AuthFlowStore {
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    if (c.req.header("x-admin-key") !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 const buildApp = (store: AuthFlowStore) => {
   const app = new Hono();
 
@@ -58,7 +74,7 @@ const buildApp = (store: AuthFlowStore) => {
           store.auditActions.push("activity_publish");
         }
       },
-      adminApiKey
+      requirePermission: requireAdminPermission
     })
   );
 
@@ -102,7 +118,8 @@ const buildApp = (store: AuthFlowStore) => {
         async executeActivity() {
           return { recordId: 1, status: "submitted" as const };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 

--- a/tests/integration/authorization-regression.test.ts
+++ b/tests/integration/authorization-regression.test.ts
@@ -21,6 +21,22 @@ const requireStudentAuth: MiddlewareHandler = async (c, next) => {
   await next();
 };
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    if (c.req.header("x-admin-key") !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 const createApp = () => {
   const app = new Hono();
 
@@ -62,7 +78,7 @@ const createApp = () => {
           return;
         }
       },
-      adminApiKey
+      requirePermission: requireAdminPermission
     })
   );
 
@@ -121,7 +137,8 @@ const createApp = () => {
         async executeActivity() {
           return { recordId: 1, status: "submitted" as const };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 

--- a/tests/metrics/admin-dimension-aggregation.test.ts
+++ b/tests/metrics/admin-dimension-aggregation.test.ts
@@ -5,6 +5,16 @@ import { createAdminRoutes } from "../../src/routes/admin.ts";
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    const requestAdminKey = c.req.header("x-admin-key") ?? c.req.header("X-Admin-Key");
+    if (requestAdminKey !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
 interface CallSnapshot {
   dimension: string;
   schoolId?: number;
@@ -88,7 +98,8 @@ const createApp = (calls: CallSnapshot[] = []) => {
           };
         }
       },
-      adminApiKey
+      adminApiKey,
+      requirePermission: requireAdminPermission
     })
   );
 

--- a/tests/metrics/admin-trend-funnel.test.ts
+++ b/tests/metrics/admin-trend-funnel.test.ts
@@ -5,6 +5,16 @@ import { createAdminRoutes } from "../../src/routes/admin.ts";
 
 const adminApiKey = "admin-secret-key";
 
+const requireAdminPermission = () => {
+  return async (c: { req: { header(name: string): string | undefined }; json: Function }, next: () => Promise<void>) => {
+    const requestAdminKey = c.req.header("x-admin-key") ?? c.req.header("X-Admin-Key");
+    if (requestAdminKey !== adminApiKey) {
+      return c.json({ message: "forbidden" }, 403);
+    }
+    await next();
+  };
+};
+
 const createApp = () => {
   const app = new Hono();
 
@@ -78,7 +88,8 @@ const createApp = () => {
           };
         }
       },
-      adminApiKey
+      adminApiKey,
+      requirePermission: requireAdminPermission
     })
   );
 

--- a/tests/teacher/activity-execution.test.ts
+++ b/tests/teacher/activity-execution.test.ts
@@ -8,6 +8,13 @@ import {
 } from "../../src/modules/teacher/activity-execution.ts";
 import { createTeacherRoutes } from "../../src/routes/teacher.ts";
 
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 test("teacher activity execution service should upsert execution payload", async () => {
   let saved = 0;
   const repo: TeacherActivityExecutionRepository = {
@@ -71,7 +78,8 @@ test("POST /teacher/activities/:id/execute should return 403 when teacher not as
         async executeActivity() {
           throw new TeacherActivityForbiddenError();
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 
@@ -95,7 +103,8 @@ test("POST /teacher/activities/:id/execute should return submitted record id", a
         async executeActivity() {
           return { recordId: 9, status: "submitted" as const };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 

--- a/tests/teacher/my-students.test.ts
+++ b/tests/teacher/my-students.test.ts
@@ -5,6 +5,13 @@ import { createTeacherMyStudentsService, type TeacherMyStudentsRepository } from
 import { createAuthorizationGrantService } from "../../src/modules/authorization/grant-service.ts";
 import { createTeacherRoutes } from "../../src/routes/teacher.ts";
 
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 test("teacher my students service should keep stable pagination order by studentId", async () => {
   const repo: TeacherMyStudentsRepository = {
     async listAuthorizedStudents() {
@@ -76,7 +83,8 @@ test("GET /teacher/my-students should require teacher id", async () => {
         async getMyStudents() {
           return { page: 1, pageSize: 20, total: 0, items: [] };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 
@@ -120,7 +128,8 @@ test("GET /teacher/my-students should support filters and pagination", async () 
             ]
           };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 

--- a/tests/teacher/student-detail.test.ts
+++ b/tests/teacher/student-detail.test.ts
@@ -8,6 +8,13 @@ import {
 } from "../../src/modules/teacher/student-detail.ts";
 import { createTeacherRoutes } from "../../src/routes/teacher.ts";
 
+const resolveTeacherIdFromLegacyHeader = (request: {
+  req: { header(name: string): string | undefined };
+}): string | null => {
+  const teacherId = request.req.header("x-teacher-id")?.trim();
+  return teacherId?.length ? teacherId : null;
+};
+
 test("teacher student detail service should aggregate profile/assessment/report/task/certificate", async () => {
   const repo: TeacherStudentDetailRepository = {
     async isStudentAuthorized() {
@@ -93,7 +100,8 @@ test("GET /teacher/students/:id/detail should return 403 when unauthorized", asy
         async getStudentDetail() {
           throw new TeacherStudentDetailForbiddenError();
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 
@@ -124,7 +132,8 @@ test("GET /teacher/students/:id/detail should return aggregated detail", async (
             certificateFiles: [{ fileId: "f1", originalName: "a.pdf", mimeType: "application/pdf", sizeBytes: 1 }]
           };
         }
-      }
+      },
+      resolveTeacherId: resolveTeacherIdFromLegacyHeader
     })
   );
 


### PR DESCRIPTION
## 背景
- 父任务：#69（全链路统一 RBAC 鉴权重构）
- 本 PR 聚焦 platform 后端统一认证与授权链路

## 本次改造
- 接入统一会话认证：`POST /auth/login`、`POST /auth/refresh`、`POST /auth/logout`、`GET /auth/me`
- 接入 refresh token 轮转与撤销
- 统一鉴权中间件链路到 session auth
- 接入 RBAC permission/scope 决策（role + permission + scope）
- 移除 `src/` 内旧头鉴权依赖（`X-Teacher-Id` / `X-Admin-Key`）
- 兼容并补齐旧会话测试所需能力（session-service/session-token/auth route）

## 验证
- [x] `pnpm build`
- [x] `pnpm test`（164/164）

## 联动 PR
- manager：Typeve/lesi-edu-manager#20
- stu：Typeve/lesi-edu-stu#15

Refs #69
